### PR TITLE
Feature/114/add kube context flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,16 @@ var rootCmd = &cobra.Command{
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
+  PersistentPreRun: func(cmd *cobra.Command, args []string) {
+    //Initialise the kubeconfig
+    kubernetesClient, err := kubernetes.NewClient(masterURL, kubeconfig)
+    if err != nil {
+      color.Red("Error initialising kubernetes client: %v", err)
+      os.Exit(1)
+    }
+
+    viper.Set("kubernetesClient", kubernetesClient)
+  },
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -55,14 +65,6 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-	//Initialise the kubeconfig
-	kubernetesClient, err := kubernetes.NewClient(masterURL, kubeconfig)
-	if err != nil {
-		color.Red("Error initialising kubernetes client: %v", err)
-	}
-
-	viper.Set("kubernetesClient", kubernetesClient)
 
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ var (
 	masterURL  string
 	kubeconfig string
 	version    string
+	k8sContext string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -30,7 +31,7 @@ var rootCmd = &cobra.Command{
 	// Run: func(cmd *cobra.Command, args []string) { },
   PersistentPreRun: func(cmd *cobra.Command, args []string) {
     //Initialise the kubeconfig
-    kubernetesClient, err := kubernetes.NewClient(masterURL, kubeconfig)
+    kubernetesClient, err := kubernetes.NewClient(masterURL, kubeconfig, k8sContext)
     if err != nil {
       color.Red("Error initialising kubernetes client: %v", err)
       os.Exit(1)
@@ -62,6 +63,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.k8sgpt.yaml)")
 	rootCmd.PersistentFlags().StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	rootCmd.PersistentFlags().StringVarP(&k8sContext, "kube-context", "", "", "Kubernetes context to be used")
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -14,7 +14,7 @@ func (c *Client) GetClient() *kubernetes.Clientset {
 	return c.client
 }
 
-func NewClient(masterURL string, kubeconfig string) (*Client, error) {
+func NewClient(masterURL string, kubeconfig string, context string) (*Client, error) {
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -28,6 +28,10 @@ func NewClient(masterURL string, kubeconfig string) (*Client, error) {
 
 		if masterURL != "" {
 			configOverrides.ClusterInfo.Server = masterURL
+		}
+
+		if context != "" {
+			configOverrides.CurrentContext = context
 		}
 
 		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loaderRules, configOverrides)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -18,9 +18,20 @@ func NewClient(masterURL string, kubeconfig string) (*Client, error) {
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		kubeconfig :=
-			clientcmd.NewDefaultClientConfigLoadingRules().GetDefaultFilename()
-		config, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		loaderRules := clientcmd.NewDefaultClientConfigLoadingRules()
+
+		if kubeconfig != "" {
+			loaderRules.Precedence = []string{kubeconfig}
+		}
+
+		configOverrides := &clientcmd.ConfigOverrides{}
+
+		if masterURL != "" {
+			configOverrides.ClusterInfo.Server = masterURL
+		}
+
+		kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loaderRules, configOverrides)
+		config, err = kubeConfig.ClientConfig()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
This PR adds the possibility to specify which kubernetes context should be used when running the
command. It also fixes the issue that the `master` and `kubeconfig` parameters where not honored. 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->