### PR TITLE
fix: kubecontext flag has no effect

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,15 +61,6 @@ func init() {
 	// when this action is called directly.
 	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	//Initialise the kubeconfig
-	kubernetesClient, err := kubernetes.NewClient(kubecontext, kubeconfig)
-	if err != nil {
-		color.Red("Error initialising kubernetes client: %v", err)
-		os.Exit(1)
-	}
-
-	viper.Set("kubernetesClient", kubernetesClient)
-
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -89,6 +80,15 @@ func initConfig() {
 
 		viper.SafeWriteConfig()
 	}
+
+	//Initialise the kubeconfig
+	kubernetesClient, err := kubernetes.NewClient(kubecontext, kubeconfig)
+	if err != nil {
+		color.Red("Error initialising kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	viper.Set("kubernetesClient", kubernetesClient)
 
 	viper.AutomaticEnv() // read in environment variables that match
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #164

## 📑 Description
<!-- Add a brief description of the pr -->

As @Antvirf pointed out in their issue https://github.com/k8sgpt-ai/k8sgpt/issues/164, the `kubecontext` flag was not being taken into account. To fix this issue, I moved the context initialization to the `initConfig` method.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Based on my tests, it is now functional : 

```
➜  k8sgpt git:(main) ✗ ./k8sgpt --kubecontext existing-context analyze --namespace my-ns -o json 
{ "status": "OK" }
➜  k8sgpt git:(main) ✗ ./k8sgpt --kubecontext fakeContext analyze --namespace my-ns -o json 
Error initialising kubernetes client: context "fakeContext" does not exist
➜  k8sgpt git:(main) ✗ ./k8sgpt analyze --namespace my-ns -o json 
{ "status": "OK" }
```
