### PR TITLE
feat: add pdb analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ you will be able to write your own analyzers.
 #### Optional
 
 - [x] hpaAnalyzer
+- [x] pdbAnalyzer
 
 ## Usage
 

--- a/pkg/analyzer/analysis.go
+++ b/pkg/analyzer/analysis.go
@@ -22,7 +22,7 @@ type PreAnalysis struct {
 	Endpoint                 v1.Endpoints
 	Ingress                  networkingv1.Ingress
 	HorizontalPodAutoscalers autoscalingv1.HorizontalPodAutoscaler
-	PodDiscruptionBudget     policyv1.PodDisruptionBudget
+	PodDisruptionBudget      policyv1.PodDisruptionBudget
 }
 
 type Analysis struct {

--- a/pkg/analyzer/analysis.go
+++ b/pkg/analyzer/analysis.go
@@ -5,6 +5,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 )
 
 type AnalysisConfiguration struct {
@@ -21,6 +22,7 @@ type PreAnalysis struct {
 	Endpoint                 v1.Endpoints
 	Ingress                  networkingv1.Ingress
 	HorizontalPodAutoscalers autoscalingv1.HorizontalPodAutoscaler
+	PodDiscruptionBudget     policyv1.PodDisruptionBudget
 }
 
 type Analysis struct {

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -23,6 +23,7 @@ var coreAnalyzerMap = map[string]func(ctx context.Context, config *AnalysisConfi
 var additionalAnalyzerMap = map[string]func(ctx context.Context, config *AnalysisConfiguration,
 	client *kubernetes.Client, aiClient ai.IAI, analysisResults *[]Analysis) error{
 	"HorizontalPodAutoScaler": AnalyzeHpa,
+	"PodDisruptionBudget":     AnalyzePdb,
 }
 
 func RunAnalysis(ctx context.Context, filters []string, config *AnalysisConfiguration,

--- a/pkg/analyzer/events.go
+++ b/pkg/analyzer/events.go
@@ -2,42 +2,17 @@ package analyzer
 
 import (
 	"context"
-
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func FetchLatestPodEvent(ctx context.Context, kubernetesClient *kubernetes.Client, pod *v1.Pod) (*v1.Event, error) {
+func FetchLatestEvent(ctx context.Context, kubernetesClient *kubernetes.Client, namespace string, name string) (*v1.Event, error) {
 
 	// get the list of events
-	events, err := kubernetesClient.GetClient().CoreV1().Events(pod.Namespace).List(ctx,
+	events, err := kubernetesClient.GetClient().CoreV1().Events(namespace).List(ctx,
 		metav1.ListOptions{
-			FieldSelector: "involvedObject.name=" + pod.Name,
-		})
-
-	if err != nil {
-		return nil, err
-	}
-	// find most recent event
-	var latestEvent *v1.Event
-	for _, event := range events.Items {
-		if latestEvent == nil {
-			latestEvent = &event
-		}
-		if event.LastTimestamp.After(latestEvent.LastTimestamp.Time) {
-			latestEvent = &event
-		}
-	}
-	return latestEvent, nil
-}
-
-func FetchLatestPvcEvent(ctx context.Context, kubernetesClient *kubernetes.Client, pvc *v1.PersistentVolumeClaim) (*v1.Event, error) {
-
-	// get the list of events
-	events, err := kubernetesClient.GetClient().CoreV1().Events(pvc.Namespace).List(ctx,
-		metav1.ListOptions{
-			FieldSelector: "involvedObject.name=" + pvc.Name,
+			FieldSelector: "involvedObject.name=" + name,
 		})
 
 	if err != nil {

--- a/pkg/analyzer/pdbAnalyzer.go
+++ b/pkg/analyzer/pdbAnalyzer.go
@@ -1,0 +1,64 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func AnalyzePdb(ctx context.Context, config *AnalysisConfiguration, client *kubernetes.Client, aiClient ai.IAI,
+	analysisResults *[]Analysis) error {
+
+	list, err := client.GetClient().PolicyV1().PodDisruptionBudgets(config.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	var preAnalysis = map[string]PreAnalysis{}
+
+	for _, pdb := range list.Items {
+		var failures []string
+
+		evt, err := FetchLatestEvent(ctx, client, pdb.Namespace, pdb.Name)
+		if err != nil || evt == nil {
+			continue
+		}
+
+		if evt.Reason == "NoPods" && evt.Message != "" {
+			if pdb.Spec.Selector != nil {
+				for k, v := range pdb.Spec.Selector.MatchLabels {
+					failures = append(failures, fmt.Sprintf("%s, expected label %s=%s", evt.Message, k, v))
+				}
+				for _, v := range pdb.Spec.Selector.MatchExpressions {
+					failures = append(failures, fmt.Sprintf("%s, expected expression %s", evt.Message, v))
+				}
+			} else {
+				failures = append(failures, fmt.Sprintf("%s, selector is nil", evt.Message))
+			}
+		}
+
+		if len(failures) > 0 {
+			preAnalysis[fmt.Sprintf("%s/%s", pdb.Namespace, pdb.Name)] = PreAnalysis{
+				PodDiscruptionBudget: pdb,
+				FailureDetails:       failures,
+			}
+		}
+	}
+
+	for key, value := range preAnalysis {
+		var currentAnalysis = Analysis{
+			Kind:  "PodDisruptionBudget",
+			Name:  key,
+			Error: value.FailureDetails,
+		}
+
+		parent, _ := util.GetParent(client, value.PodDiscruptionBudget.ObjectMeta)
+		currentAnalysis.ParentObject = parent
+		*analysisResults = append(*analysisResults, currentAnalysis)
+	}
+
+	return nil
+}

--- a/pkg/analyzer/pdbAnalyzer.go
+++ b/pkg/analyzer/pdbAnalyzer.go
@@ -42,8 +42,8 @@ func AnalyzePdb(ctx context.Context, config *AnalysisConfiguration, client *kube
 
 		if len(failures) > 0 {
 			preAnalysis[fmt.Sprintf("%s/%s", pdb.Namespace, pdb.Name)] = PreAnalysis{
-				PodDiscruptionBudget: pdb,
-				FailureDetails:       failures,
+				PodDisruptionBudget: pdb,
+				FailureDetails:      failures,
 			}
 		}
 	}
@@ -55,7 +55,7 @@ func AnalyzePdb(ctx context.Context, config *AnalysisConfiguration, client *kube
 			Error: value.FailureDetails,
 		}
 
-		parent, _ := util.GetParent(client, value.PodDiscruptionBudget.ObjectMeta)
+		parent, _ := util.GetParent(client, value.PodDisruptionBudget.ObjectMeta)
 		currentAnalysis.ParentObject = parent
 		*analysisResults = append(*analysisResults, currentAnalysis)
 	}

--- a/pkg/analyzer/podAnalyzer.go
+++ b/pkg/analyzer/podAnalyzer.go
@@ -47,7 +47,7 @@ func AnalyzePod(ctx context.Context, config *AnalysisConfiguration,
 				if containerStatus.State.Waiting.Reason == "ContainerCreating" && pod.Status.Phase == "Pending" {
 
 					// parse the event log and append details
-					evt, err := FetchLatestPodEvent(ctx, client, &pod)
+					evt, err := FetchLatestEvent(ctx, client, pod.Namespace, pod.Name)
 					if err != nil || evt == nil {
 						continue
 					}

--- a/pkg/analyzer/pvcAnalyzer.go
+++ b/pkg/analyzer/pvcAnalyzer.go
@@ -27,7 +27,7 @@ func AnalyzePersistentVolumeClaim(ctx context.Context, config *AnalysisConfigura
 		if pvc.Status.Phase == "Pending" {
 
 			// parse the event log and append details
-			evt, err := FetchLatestPvcEvent(ctx, client, &pvc)
+			evt, err := FetchLatestEvent(ctx, client, pvc.Namespace, pvc.Name)
 			if err != nil || evt == nil {
 				continue
 			}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #163

## 📑 Description

This PR adds a PDB analyzer, which checks all PDBs if their selector configuration matches any existing pods. The filter is disabled by default and can be activated with `k8sgpt filters add PodDisruptionBudget`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

```
k8sgpt filters list
                                                                                                                                      
Active:                                                                                                                                                                                                            
> ReplicaSet                                                                                                                                                                                                       > PersistentVolumeClaim                                                                                                                                                                                            
> Service                                                                                                                                                                                                          
> Ingress                                                                                                                                                                                                          
> Pod                                                                                                                                                                                                              
Unused:                                                                                                                                                                                                            
> HorizontalPodAutoScaler                                                                                                                                                                                          
> PodDisruptionBudget
```

```
k8sgpt analyze --explain

0 test2/podtato-head(podtato-head)
- Error: No matching pods found, selector is nil
Error message: 
No matching pods found, selector is nil

Solution: 
This error is typically returned when a Kubernetes resource, such as a deployment or service, specifies a null selector, meaning it cannot identify which pod(s) to target in the cluster. To fix this, you need to add a valid selector to your resource configuration so that it can identify the right pod(s) to manage or connect with.

1 default/podtato-head(podtato-head)
- Error: No matching pods found, expected label app=podtato-head
- Error: No matching pods found, expected label env=banana-head
Error message: Kubernetes is unable to find pods with the expected labels "app=podtato-head" and "env=banana-head."

Solution: Add the missing labels to the relevant pod deployment and ensure that the labels are correctly specified in the Kubernetes configuration file or command. Alternatively, use a different selector that matches the existing labels of the pods.

2 demo-dev/podtato-head(podtato-head)
- Error: No matching pods found, expected label app=podtato-head
- Error: No matching pods found, expected expression {environment NotIn [test]}
- Error: No matching pods found, expected expression {application NotIn [test]}
The error message means that the Kubernetes system was unable to find any pods with the required labels and expressions. The labels and expressions mentioned are "app=podtato-head", "environment NotIn [test]", and "application NotIn [test]". To resolve the issue, you need to ensure that the pods are properly labeled and have the required expressions configured. Check the Kubernetes configuration files to confirm that the labels and expressions are set correctly.
```