### PR TITLE
fix: hpaAnalyzer analysis result is using wrong parent

### DIFF
--- a/pkg/analyzer/hpaAnalyzer.go
+++ b/pkg/analyzer/hpaAnalyzer.go
@@ -72,7 +72,7 @@ func AnalyzeHpa(ctx context.Context, config *AnalysisConfiguration, client *kube
 			Error: value.FailureDetails,
 		}
 
-		parent, _ := util.GetParent(client, value.Ingress.ObjectMeta)
+		parent, _ := util.GetParent(client, value.HorizontalPodAutoscalers.ObjectMeta)
 		currentAnalysis.ParentObject = parent
 		*analysisResults = append(*analysisResults, currentAnalysis)
 	}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
The hpaAnalyzer is using the `Ingress.ObjectMeta` instead of the `HorizontalPodAutoscalers.ObjectMeta` to get its parent.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
