### PR TITLE
feat: add password flag for backend authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ If you install gcc as suggested, the problem will persist. Therefore, you need t
 
 * Currently the default AI provider is OpenAI, you will need to generate an API key from [OpenAI](https://openai.com)
   * You can do this by running `k8sgpt generate` to open a browser link to generate it
-* Run `k8sgpt auth` to set it in k8sgpt.
+* Run `k8sgpt auth` to set it in k8sgpt. 
+  * You can provide the password directly using the `--password` flag.
 * Run `k8sgpt filters` to manage the active filters used by the analyzer. By default, all filters are executed during analysis.
 * Run `k8sgpt analyze` to run a scan.
 * And use `k8sgpt analyze --explain` to get a more detailed explanation of the issues.

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	backend string
+	backend  string
+	password string
 )
 
 // authCmd represents the auth command
@@ -38,14 +39,16 @@ var AuthCmd = &cobra.Command{
 			color.Green("Using %s as backend AI provider", backendType)
 		}
 
-		fmt.Printf("Enter %s Key: ", backendType)
-		bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-		if err != nil {
-			color.Red("Error reading %s Key from stdin: %s", backendType,
-				err.Error())
-			os.Exit(1)
+		if password == "" {
+			fmt.Printf("Enter %s Key: ", backendType)
+			bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+			if err != nil {
+				color.Red("Error reading %s Key from stdin: %s", backendType,
+					err.Error())
+				os.Exit(1)
+			}
+			password = strings.TrimSpace(string(bytePassword))
 		}
-		password := strings.TrimSpace(string(bytePassword))
 
 		viper.Set(fmt.Sprintf("%s_key", backendType), password)
 		if err := viper.WriteConfig(); err != nil {
@@ -59,4 +62,6 @@ var AuthCmd = &cobra.Command{
 func init() {
 	// add flag for backend
 	AuthCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
+	// add flag for password
+	AuthCmd.Flags().StringVarP(&password, "password", "p", "", "Backend AI password")
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #180 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

The code modification added a password flag for backend authentication in the auth package. Previously, users had to enter their password in the terminal when authenticating with the chosen backend, but with this modification, they can provide the password as a flag when running the authentication command.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->