### PR TITLE
feat!: add support for new configuration format

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/fatih/color"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -14,6 +15,7 @@ import (
 
 var (
 	backend  string
+	model    string
 	password string
 )
 
@@ -24,19 +26,25 @@ var AuthCmd = &cobra.Command{
 	Long:  `Provide the necessary credentials to authenticate with your chosen backend.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
+		configAI := ai.AIConfiguration{
+			Providers: []ai.AIProvider{},
+		}
+
+		defaultProvider := ai.AIProvider{}
+
 		backendType := viper.GetString("backend_type")
 		if backendType == "" {
 			// Set the default backend
-			viper.Set("backend_type", "openai")
-			if err := viper.WriteConfig(); err != nil {
-				color.Red("Error writing config file: %s", err.Error())
-				os.Exit(1)
-			}
+			defaultProvider.Name = "openai"
 		}
 		// override the default backend if a flag is provided
 		if backend != "" {
-			backendType = backend
+			defaultProvider.Name = backend
 			color.Green("Using %s as backend AI provider", backendType)
+		}
+
+		if model != "" {
+			defaultProvider.Model = model
 		}
 
 		if password == "" {
@@ -50,7 +58,10 @@ var AuthCmd = &cobra.Command{
 			password = strings.TrimSpace(string(bytePassword))
 		}
 
-		viper.Set(fmt.Sprintf("%s_key", backendType), password)
+		defaultProvider.Password = password
+
+		configAI.Providers = append(configAI.Providers, defaultProvider)
+		viper.Set("ai", configAI)
 		if err := viper.WriteConfig(); err != nil {
 			color.Red("Error writing config file: %s", err.Error())
 			os.Exit(1)
@@ -62,6 +73,8 @@ var AuthCmd = &cobra.Command{
 func init() {
 	// add flag for backend
 	AuthCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
+	// add flag for model
+	AuthCmd.Flags().StringVarP(&model, "model", "m", "gpt-3.5-turbo", "Backend AI model")
 	// add flag for password
 	AuthCmd.Flags().StringVarP(&password, "password", "p", "", "Backend AI password")
 }

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -43,7 +43,6 @@ func (c *OpenAIClient) Configure(token string, model string, language string) er
 }
 
 func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
-
 	// Create a completion request
 	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
 		Model: c.model,

--- a/pkg/ai/ai.go
+++ b/pkg/ai/ai.go
@@ -15,25 +15,38 @@ const (
 	prompt_c       = "Reading the following %s error message and it's accompanying log message %s, how would you simplify this message?"
 )
 
+type AIConfiguration struct {
+	Providers []AIProvider `mapstructure:"providers"`
+}
+
+type AIProvider struct {
+	Name     string `mapstructure:"name"`
+	Model    string `mapstructure:"model"`
+	Password string `mapstructure:"password"`
+}
+
 type OpenAIClient struct {
 	client   *openai.Client
 	language string
+	model    string
 }
 
-func (c *OpenAIClient) Configure(token string, language string) error {
+func (c *OpenAIClient) Configure(token string, model string, language string) error {
 	client := openai.NewClient(token)
 	if client == nil {
 		return errors.New("error creating OpenAI client")
 	}
 	c.language = language
 	c.client = client
+	c.model = model
 	return nil
 }
 
 func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+
 	// Create a completion request
 	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
-		Model: openai.GPT3Dot5Turbo,
+		Model: c.model,
 		Messages: []openai.ChatCompletionMessage{
 			{
 				Role:    "user",

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -3,6 +3,6 @@ package ai
 import "context"
 
 type IAI interface {
-	Configure(token string, language string) error
+	Configure(token string, model string, language string) error
 	GetCompletion(ctx context.Context, prompt string) (string, error)
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #167

## 📑 Description
<!-- Add a brief description of the pr -->

This commit adds support for a new configuration format that is not backwards compatible with the previous format. This is a breaking change and requires users to update their configuration files to use the new format.

BREAKING CHANGE: The format of the configuration file has changed. Users must update their configuration files to use the new format.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Last configuration format : 

```yaml
backend_type: openai
openai_key: xxxxxx
```

New configuration format : 

```yaml
ai:
    providers:
        - name: openai
          model: gpt-3.5-turbo
          password: xxxxxx
```

If the configuration format is incorrect : 

```bash
➜  k8sgpt git:(feature/config-new-format) ✗ ./k8sgpt analyze --namespace k8sgpt --explain --no-cache
Error: AI provider not specified in configuration. Please run k8sgpt auth
```

If the provider name is not configured : 

```bash
➜  k8sgpt git:(feature/config-new-format) ✗ ./k8sgpt analyze --namespace k8sgpt --explain --no-cache --backend fake
Error: AI provider fake not specified in configuration. Please run k8sgpt auth
```