### PR TITLE
feat: add storage class names' check.

### DIFF
--- a/pkg/analyzer/statefulset_test.go
+++ b/pkg/analyzer/statefulset_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/magiconair/properties/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -75,4 +77,70 @@ func TestStatefulSetAnalyzerWithoutService(t *testing.T) {
 	if !errorFound {
 		t.Errorf("Error expected: '%v', not found in StatefulSet's analysis results", want)
 	}
+}
+
+func TestStatefulSetAnalyzerMissingStorageClass(t *testing.T) {
+	storageClassName := "example-sc"
+	clientset := fake.NewSimpleClientset(
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: "example-svc",
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+					{
+						TypeMeta: metav1.TypeMeta{
+							Kind:       "PersistentVolumeClaim",
+							APIVersion: "v1",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "pvc-example",
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							StorageClassName: &storageClassName,
+							AccessModes: []corev1.PersistentVolumeAccessMode{
+								"ReadWriteOnce",
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceStorage: resource.MustParse("1Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	statefulSetAnalyzer := StatefulSetAnalyzer{}
+
+	config := Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := statefulSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	var errorFound bool
+	want := "StatefulSet uses the storage class example-sc which does not exist."
+
+	for _, analysis := range analysisResults {
+		for _, got := range analysis.Error {
+			if want == got {
+				errorFound = true
+			}
+		}
+		if errorFound {
+			break
+		}
+	}
+	if !errorFound {
+		t.Errorf("Error expected: '%v', not found in StatefulSet's analysis results", want)
+	}
+
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
This PR adds a check against missing storage class resources in a StatefulSet's VolumeClaimTemplate

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
A missing storage class will be caught also from the PVC analyzer with a more generic error ` Error: storageclass.storage.k8s.io "example-storage-class" not found`.
I believe adding the storage class analysis in StatefulSets will provide a better explanation to the end user.

I see PVC analyzer as a more generic underlying mechanism to report generic issues/events in a cluster but eager to get any feedback where to draw the line for possible overlapping issues.