### PR TITLE
feat: return errors if filter specified by flag does not exist.

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -72,6 +73,8 @@ func (a *Analysis) RunAnalysis() error {
 					return err
 				}
 				a.Results = append(a.Results, results...)
+			} else {
+				return errors.New(fmt.Sprintf("\"%s\" filter does not exist. Please run k8sgpt filters list.", filter))
 			}
 		}
 		return nil


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #216

## 📑 Description
<!-- Add a brief description of the pr -->

This PR adds an else clause to the AnalyzeFilters method in order to handle cases where a specified filter does not exist. Previously, when an unknown filter was passed, the method would simply return `No problems detected`. With this change, if the filter is not found in the analyzerMap, the method will return an error message that includes the name of the filter, directing the user to run `k8sgpt filters list`.

This enhancement improves the user experience and helps ensure that errors are caught and reported in a clear and helpful manner.

```bash
k8sgpt git:(feature/log-on-unexisted-filters) ✗ ./k8sgpt analyze --filter fake --namespace k8sgpt
Error: "fake" filter does not exist. Please run k8sgpt filters list.
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->