### PR TITLE
fix: add new line after version cmd output

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,7 +10,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of k8sgpt",
 	Long:  `All software has versions. This is k8sgpt's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Printf("k8sgpt version %s", version)
+		cmd.Printf("k8sgpt version %s\n", version)
 	},
 }
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#262](https://github.com/k8sgpt-ai/k8sgpt/issues/262) <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Add a new line after the version command output.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Before
```
./k8sgpt version
k8sgpt version dev%
```

After
```
./k8sgpt version
k8sgpt version dev
```