### PR TITLE
feat: add support for more complex token types

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"golang.org/x/term"
 )
 
@@ -41,8 +41,7 @@ var AuthCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// get ai configuration
-		var configAI ai.AIConfiguration
-		err := viper.UnmarshalKey("ai", &configAI)
+		configAI, err := config.LoadAIConfiguration()
 		if err != nil {
 			color.Red("Error: %v", err)
 			os.Exit(1)
@@ -83,11 +82,13 @@ var AuthCmd = &cobra.Command{
 		}
 
 		// create new provider object
-		newProvider := ai.AIProvider{
-			Name:     backend,
-			Model:    model,
-			Password: password,
-			BaseURL:  baseURL,
+		newProvider := config.AIProvider{
+			Name:    backend,
+			Model:   model,
+			BaseURL: baseURL,
+			Password: config.SimpleTextPasswordProvider{
+				Password: password,
+			},
 		}
 
 		if providerIndex == -1 {
@@ -99,11 +100,8 @@ var AuthCmd = &cobra.Command{
 			configAI.Providers[providerIndex] = newProvider
 			color.Green("Provider updated")
 		}
-		viper.Set("ai", configAI)
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("Error writing config file: %s", err.Error())
-			os.Exit(1)
-		}
+		config.SetAIConfig(configAI)
+		config.PersistOrFail()
 		color.Green("key added")
 	},
 }

--- a/cmd/filters/add.go
+++ b/cmd/filters/add.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/analyzer"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var addCmd = &cobra.Command{
@@ -59,7 +59,7 @@ var addCmd = &cobra.Command{
 		}
 
 		// Get defined active_filters
-		activeFilters := viper.GetStringSlice("active_filters")
+		activeFilters := config.ListActiveFilters()
 		if len(activeFilters) == 0 {
 			activeFilters = coreFilters
 		}
@@ -73,13 +73,8 @@ var addCmd = &cobra.Command{
 			color.Red("Duplicate filters found: %s", strings.Join(dupplicatedFilters, ", "))
 			os.Exit(1)
 		}
-
-		viper.Set("active_filters", uniqueFilters)
-
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("Error writing config file: %s", err.Error())
-			os.Exit(1)
-		}
+		config.SetActiveFilters(uniqueFilters)
+		config.PersistOrFail()
 		color.Green("Filter %s added", strings.Join(inputFilters, ", "))
 	},
 }

--- a/cmd/filters/list.go
+++ b/cmd/filters/list.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/analyzer"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var listCmd = &cobra.Command{
@@ -28,7 +28,7 @@ var listCmd = &cobra.Command{
 	Short: "List available filters",
 	Long:  `The list command displays a list of available filters that can be used to analyze Kubernetes resources.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		activeFilters := viper.GetStringSlice("active_filters")
+		activeFilters := config.ListActiveFilters()
 		coreFilters, additionalFilters, integrationFilters := analyzer.ListFilters()
 
 		availableFilters := append(append(coreFilters, additionalFilters...), integrationFilters...)

--- a/cmd/filters/remove.go
+++ b/cmd/filters/remove.go
@@ -19,9 +19,9 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/analyzer"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 var removeCmd = &cobra.Command{
@@ -33,7 +33,7 @@ var removeCmd = &cobra.Command{
 		inputFilters := strings.Split(args[0], ",")
 
 		// Get defined active_filters
-		activeFilters := viper.GetStringSlice("active_filters")
+		activeFilters := config.ListActiveFilters()
 		coreFilters, _, _ := analyzer.ListFilters()
 
 		if len(activeFilters) == 0 {
@@ -75,13 +75,8 @@ var removeCmd = &cobra.Command{
 			color.Red("Filter(s) %s does not exist in configuration file. Please use k8sgpt filters add.", strings.Join(filterNotFound, ", "))
 			os.Exit(1)
 		}
-
-		viper.Set("active_filters", activeFilters)
-
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("Error writing config file: %s", err.Error())
-			os.Exit(1)
-		}
+		config.SetActiveFilters(activeFilters)
+		config.PersistOrFail()
 		color.Green("Filter(s) %s removed", strings.Join(inputFilters, ", "))
 	},
 }

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -15,11 +15,12 @@ package generate
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"os/exec"
 	"runtime"
+
+	"github.com/fatih/color"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -33,7 +34,7 @@ var GenerateCmd = &cobra.Command{
 	Long:  `Opens your browser to generate a key for your chosen backend.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		backendType := viper.GetString("backend_type")
+		backendType := config.GetBackendType()
 		if backendType == "" {
 			// Set the default backend
 			backend = "openai"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,17 +17,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
 	"github.com/adrg/xdg"
 	"github.com/fatih/color"
-	"github.com/k8sgpt-ai/k8sgpt/cmd/serve"
-	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/k8sgpt-ai/k8sgpt/cmd/analyze"
 	"github.com/k8sgpt-ai/k8sgpt/cmd/auth"
 	"github.com/k8sgpt-ai/k8sgpt/cmd/filters"
 	"github.com/k8sgpt-ai/k8sgpt/cmd/generate"
 	"github.com/k8sgpt-ai/k8sgpt/cmd/integration"
+	"github.com/k8sgpt-ai/k8sgpt/cmd/serve"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/client-go/util/homedir"
 )
 
@@ -80,30 +81,12 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// the config will belocated under `~/.config/k8sgpt/k8sgpt.yaml` on linux
-		configDir := filepath.Join(xdg.ConfigHome, "k8sgpt")
+	config.Initialize(cfgFile)
 
-		viper.AddConfigPath(configDir)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName("k8sgpt")
-
-		viper.SafeWriteConfig()
-	}
-
-	viper.Set("kubecontext", kubecontext)
-	viper.Set("kubeconfig", kubeconfig)
-
-	viper.SetEnvPrefix("K8SGPT")
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		//	fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
+	config.SetKubernetesSettings(config.KubernetesSettings{
+		Context: kubecontext,
+		Config:  kubeconfig,
+	})
 }
 
 func performConfigMigrationIfNeeded() {

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -17,19 +17,14 @@ import (
 	"context"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 )
 
 type IAI interface {
-	Configure(config IAIConfig, language string) error
+	Configure(config config.IAIConfig, language string) error
 	GetCompletion(ctx context.Context, prompt string) (string, error)
 	Parse(ctx context.Context, prompt []string, cache cache.ICache) (string, error)
 	GetName() string
-}
-
-type IAIConfig interface {
-	GetPassword() string
-	GetModel() string
-	GetBaseURL() string
 }
 
 func NewClient(provider string) IAI {
@@ -43,29 +38,6 @@ func NewClient(provider string) IAI {
 	default:
 		return &OpenAIClient{}
 	}
-}
-
-type AIConfiguration struct {
-	Providers []AIProvider `mapstructure:"providers"`
-}
-
-type AIProvider struct {
-	Name     string `mapstructure:"name"`
-	Model    string `mapstructure:"model"`
-	Password string `mapstructure:"password"`
-	BaseURL  string `mapstructure:"baseurl"`
-}
-
-func (p *AIProvider) GetBaseURL() string {
-	return p.BaseURL
-}
-
-func (p *AIProvider) GetPassword() string {
-	return p.Password
-}
-
-func (p *AIProvider) GetModel() string {
-	return p.Model
 }
 
 func NeedPassword(backend string) bool {

--- a/pkg/ai/noopai.go
+++ b/pkg/ai/noopai.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 )
 
@@ -30,8 +31,13 @@ type NoOpAIClient struct {
 	model    string
 }
 
-func (c *NoOpAIClient) Configure(config IAIConfig, language string) error {
-	token := config.GetPassword()
+func (c *NoOpAIClient) Configure(config config.IAIConfig, language string) error {
+	token, err := config.GetPassword()
+
+	if err != nil {
+		return err
+	}
+
 	c.language = language
 	c.client = fmt.Sprintf("I am a noop client with the token %s ", token)
 	c.model = config.GetModel()

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/config"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 
 	"github.com/sashabaranov/go-openai"
@@ -34,8 +35,13 @@ type OpenAIClient struct {
 	model    string
 }
 
-func (c *OpenAIClient) Configure(config IAIConfig, language string) error {
-	token := config.GetPassword()
+func (c *OpenAIClient) Configure(config config.IAIConfig, language string) error {
+	token, err := config.GetPassword()
+
+	if err != nil {
+		return err
+	}
+
 	defaultConfig := openai.DefaultConfig(token)
 
 	baseURL := config.GetBaseURL()

--- a/pkg/analyzer/hpaAnalyzer_test.go
+++ b/pkg/analyzer/hpaAnalyzer_test.go
@@ -205,15 +205,15 @@ func TestHPAAnalyzerWithExistingScaleTargetRefAsDeployment(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "example",
+								Name:  "example",
 								Image: "nginx",
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										"cpu": resource.MustParse("100m"),
+										"cpu":    resource.MustParse("100m"),
 										"memory": resource.MustParse("128Mi"),
 									},
 									Limits: corev1.ResourceList{
-										"cpu": resource.MustParse("200m"),
+										"cpu":    resource.MustParse("200m"),
 										"memory": resource.MustParse("256Mi"),
 									},
 								},
@@ -269,15 +269,15 @@ func TestHPAAnalyzerWithExistingScaleTargetRefAsReplicationController(t *testing
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "example",
+								Name:  "example",
 								Image: "nginx",
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										"cpu": resource.MustParse("100m"),
+										"cpu":    resource.MustParse("100m"),
 										"memory": resource.MustParse("128Mi"),
 									},
 									Limits: corev1.ResourceList{
-										"cpu": resource.MustParse("200m"),
+										"cpu":    resource.MustParse("200m"),
 										"memory": resource.MustParse("256Mi"),
 									},
 								},
@@ -333,15 +333,15 @@ func TestHPAAnalyzerWithExistingScaleTargetRefAsReplicaSet(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "example",
+								Name:  "example",
 								Image: "nginx",
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										"cpu": resource.MustParse("100m"),
+										"cpu":    resource.MustParse("100m"),
 										"memory": resource.MustParse("128Mi"),
 									},
 									Limits: corev1.ResourceList{
-										"cpu": resource.MustParse("200m"),
+										"cpu":    resource.MustParse("200m"),
 										"memory": resource.MustParse("256Mi"),
 									},
 								},
@@ -397,15 +397,15 @@ func TestHPAAnalyzerWithExistingScaleTargetRefAsStatefulSet(t *testing.T) {
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "example",
+								Name:  "example",
 								Image: "nginx",
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
-										"cpu": resource.MustParse("100m"),
+										"cpu":    resource.MustParse("100m"),
 										"memory": resource.MustParse("128Mi"),
 									},
 									Limits: corev1.ResourceList{
-										"cpu": resource.MustParse("200m"),
+										"cpu":    resource.MustParse("200m"),
 										"memory": resource.MustParse("256Mi"),
 									},
 								},
@@ -461,7 +461,7 @@ func TestHPAAnalyzerWithExistingScaleTargetRefWithoutSpecifyingResources(t *test
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
-								Name: "example",
+								Name:  "example",
 								Image: "nginx",
 							},
 						},
@@ -487,7 +487,7 @@ func TestHPAAnalyzerWithExistingScaleTargetRefWithoutSpecifyingResources(t *test
 	var errorFound bool
 	for _, analysis := range analysisResults {
 		for _, err := range analysis.Error {
-			if strings.Contains(err.Text, "does not have resource configured."){
+			if strings.Contains(err.Text, "does not have resource configured.") {
 				errorFound = true
 				break
 			}

--- a/pkg/config/ai_configuration.go
+++ b/pkg/config/ai_configuration.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
+)
+
+type persistedAIConfiguration struct {
+	Providers []persistedAIProvider `mapstructure:"providers"`
+}
+
+type persistedAIProvider struct {
+	Name     string      `mapstructure:"name"`
+	Model    string      `mapstructure:"model"`
+	Password interface{} `mapstructure:"password"`
+	BaseURL  string      `mapstructure:"base_url"`
+}
+
+func LoadAIConfiguration() (AIConfiguration, error) {
+	var configAI persistedAIConfiguration
+	err := viper.UnmarshalKey("ai", &configAI)
+
+	if err != nil {
+		return AIConfiguration{}, err
+	}
+
+	return toAIConfiguration(configAI)
+}
+
+func toAIConfiguration(persisted persistedAIConfiguration) (AIConfiguration, error) {
+	var aiProviders []AIProvider
+
+	for _, provider := range persisted.Providers {
+		result, err := toAIProvider(provider)
+
+		if err != nil {
+			return AIConfiguration{}, err
+		}
+
+		aiProviders = append(aiProviders, result)
+	}
+
+	return AIConfiguration{
+		Providers: aiProviders,
+	}, nil
+}
+
+func toAIProvider(persisted persistedAIProvider) (AIProvider, error) {
+	passwordProvider, err := toPasswordProvider(persisted.Password)
+
+	if err != nil {
+		return AIProvider{}, err
+	}
+
+	return AIProvider{
+		Name:     persisted.Name,
+		Model:    persisted.Model,
+		Password: passwordProvider,
+		BaseURL:  persisted.BaseURL,
+	}, nil
+}
+
+type passwordProviderSpec struct {
+	Type      string                 `mapstructure:"type"`
+	Remaining map[string]interface{} `mapstructure:",remain"`
+}
+
+func toPasswordProvider(password interface{}) (PasswordProvider, error) {
+	switch pwd := password.(type) {
+	case map[string]interface{}:
+		var spec passwordProviderSpec
+
+		err := mapstructure.Decode(pwd, &spec)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return toPasswordProviderForType(spec.Type, spec.Remaining)
+	case string:
+		return SimpleTextPasswordProvider{Password: pwd}, nil
+	}
+
+	return nil, fmt.Errorf("cannot get password provider from: %s", password)
+}
+
+func toPasswordProviderForType(providerType string, data map[string]interface{}) (PasswordProvider, error) {
+	switch providerType {
+	case envPasswordType:
+		return parseEnvPasswordProvider(data)
+	case commandPasswordType:
+		return parseCommandPasswordProvider(data)
+	}
+
+	return nil, fmt.Errorf("unknown provider type `%s`", providerType)
+}
+
+func SetAIConfig(aiConfig AIConfiguration) {
+	persisted := toPersistedAIConfiguration(aiConfig)
+
+	viper.Set("ai", persisted)
+}
+
+func toPersistedAIConfiguration(aiConfig AIConfiguration) persistedAIConfiguration {
+	var providers []persistedAIProvider
+
+	for _, p := range aiConfig.Providers {
+		persistedProvider := toPersistedAIProvider(p)
+
+		providers = append(providers, persistedProvider)
+	}
+
+	return persistedAIConfiguration{
+		Providers: providers,
+	}
+}
+
+func toPersistedAIProvider(aiProvider AIProvider) persistedAIProvider {
+	password := toPersistedPassword(aiProvider.Password)
+
+	return persistedAIProvider{
+		Name:     aiProvider.Name,
+		Model:    aiProvider.Model,
+		Password: password,
+	}
+}
+
+func toPersistedPassword(passwordProvider PasswordProvider) interface{} {
+	switch p := passwordProvider.(type) {
+	case SimpleTextPasswordProvider:
+		return p.Password
+	case EnvPasswordProvider:
+		return map[string]string{
+			"type": envPasswordType,
+			"name": p.Name,
+		}
+	case CommandPasswordProvider:
+		return map[string]interface{}{
+			"type":      envPasswordType,
+			"command":   p.Command,
+			"arguments": p.Arguments,
+		}
+	}
+
+	fmt.Println("warning: unknown password provider! cannot persist!")
+	return nil
+}

--- a/pkg/config/command_provider.go
+++ b/pkg/config/command_provider.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"io"
+	"os/exec"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	commandPasswordType = "command"
+)
+
+var _ PasswordProvider = (*CommandPasswordProvider)(nil)
+
+type CommandPasswordProvider struct {
+	Command   string   `mapstructure:"command"`
+	Arguments []string `mapstructure:"arguments"`
+}
+
+func (r CommandPasswordProvider) GetPassword() (string, error) {
+	cmd := exec.Command(r.Command, r.Arguments...)
+	stdout, err := cmd.StdoutPipe()
+
+	if err != nil {
+		return "", err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	data, err := io.ReadAll(stdout)
+
+	if err != nil {
+		return "", err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func parseCommandPasswordProvider(data map[string]interface{}) (CommandPasswordProvider, error) {
+	var result CommandPasswordProvider
+	err := mapstructure.Decode(data, &result)
+
+	if err != nil {
+		return CommandPasswordProvider{}, err
+	}
+
+	return result, err
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+	"github.com/fatih/color"
+	"github.com/spf13/viper"
+)
+
+type IAIConfig interface {
+	GetPassword() (string, error)
+	GetModel() string
+	GetBaseURL() string
+}
+
+type AIConfiguration struct {
+	Providers []AIProvider
+}
+
+type PasswordProvider interface {
+	GetPassword() (string, error)
+}
+
+type AIProvider struct {
+	Name     string
+	Model    string
+	Password PasswordProvider
+	BaseURL  string
+}
+
+func (p *AIProvider) GetBaseURL() string {
+	return p.BaseURL
+}
+
+func (p *AIProvider) GetPassword() (string, error) {
+	return p.Password.GetPassword()
+}
+
+func (p *AIProvider) GetModel() string {
+	return p.Model
+}
+
+func GetBackendType() string {
+	return viper.GetString("backend_type")
+}
+
+func PersistOrFail() {
+	if err := viper.WriteConfig(); err != nil {
+		color.Red("Error writing config file: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
+func Initialize(cfgFile string) {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// the config will belocated under `~/.config/k8sgpt/k8sgpt.yaml` on linux
+		configDir := filepath.Join(xdg.ConfigHome, "k8sgpt")
+
+		viper.AddConfigPath(configDir)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName("k8sgpt")
+
+		// nothing we can really do in case of an error
+		_ = viper.SafeWriteConfig()
+	}
+
+	viper.SetEnvPrefix("K8SGPT")
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in. Nothing we can really do in case of an error
+	_ = viper.ReadInConfig()
+}

--- a/pkg/config/env_provider.go
+++ b/pkg/config/env_provider.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	envPasswordType = "environment"
+)
+
+var _ PasswordProvider = (*EnvPasswordProvider)(nil)
+
+func parseEnvPasswordProvider(data map[string]interface{}) (EnvPasswordProvider, error) {
+	var result EnvPasswordProvider
+	err := mapstructure.Decode(data, &result)
+
+	if err != nil {
+		return EnvPasswordProvider{}, err
+	}
+
+	return result, err
+}
+
+type EnvPasswordProvider struct {
+	Name string `mapstructure:"name"`
+}
+
+func (s EnvPasswordProvider) GetPassword() (string, error) {
+	value, found := os.LookupEnv(s.Name)
+
+	if !found {
+		return "", fmt.Errorf("cannot find env variable named `%s`", s.Name)
+	}
+
+	return value, nil
+}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+func ListActiveFilters() []string {
+	return viper.GetStringSlice("active_filters")
+}
+
+func SetActiveFilters(filters []string) {
+	viper.Set("active_filters", filters)
+}

--- a/pkg/config/kubernetes.go
+++ b/pkg/config/kubernetes.go
@@ -1,0 +1,23 @@
+package config
+
+import "github.com/spf13/viper"
+
+type KubernetesSettings struct {
+	Context string
+	Config  string
+}
+
+func LoadKubernetesSettings() KubernetesSettings {
+	kubecontext := viper.GetString("kubecontext")
+	kubeconfig := viper.GetString("kubeconfig")
+
+	return KubernetesSettings{
+		Context: kubecontext,
+		Config:  kubeconfig,
+	}
+}
+
+func SetKubernetesSettings(kubernetesSettings KubernetesSettings) {
+	viper.Set("kubecontext", kubernetesSettings.Context)
+	viper.Set("kubeconfig", kubernetesSettings.Config)
+}

--- a/pkg/config/text_provier.go
+++ b/pkg/config/text_provier.go
@@ -1,0 +1,11 @@
+package config
+
+var _ PasswordProvider = (*SimpleTextPasswordProvider)(nil)
+
+type SimpleTextPasswordProvider struct {
+	Password string
+}
+
+func (s SimpleTextPasswordProvider) GetPassword() (string, error) {
+	return s.Password, nil
+}


### PR DESCRIPTION
This commits allows you to define more complex token types, than just simple text tokens. This includes loading the token from an environment variable, or to run an arbitrary command.

This is achieved by introducing a object as potential value for `password` in the `AIProvider` config. Currently there three types supported:
* simple text
* environment variable
* process

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #239

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->