### PR TITLE
fix: deployment/cronjob analyzers namespace filtering

### DIFF
--- a/pkg/analyzer/cronjob.go
+++ b/pkg/analyzer/cronjob.go
@@ -22,7 +22,7 @@ func (analyzer CronJobAnalyzer) Analyze(a common.Analyzer) ([]common.Result, err
 
 	var results []common.Result
 
-	cronJobList, err := a.Client.GetClient().BatchV1().CronJobs("").List(a.Context, v1.ListOptions{})
+	cronJobList, err := a.Client.GetClient().BatchV1().CronJobs(a.Namespace).List(a.Context, v1.ListOptions{})
 	if err != nil {
 		return results, err
 	}

--- a/pkg/analyzer/cronjob_test.go
+++ b/pkg/analyzer/cronjob_test.go
@@ -124,3 +124,97 @@ func TestCronJobBroken(t *testing.T) {
 	assert.Equal(t, analysisResults[0].Name, "default/example-cronjob")
 	assert.Equal(t, analysisResults[0].Kind, "CronJob")
 }
+
+func TestCronJobBrokenMultipleNamespaceFiltering(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-cronjob",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"analysisDate": "2022-04-01",
+				},
+				Labels: map[string]string{
+					"app": "example-app",
+				},
+			},
+			Spec: batchv1.CronJobSpec{
+				Schedule:          "*** * * * *",
+				ConcurrencyPolicy: "Allow",
+				JobTemplate: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "example-app",
+						},
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "example-container",
+										Image: "nginx",
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				},
+			},
+		},
+		&batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-cronjob",
+				Namespace: "other-namespace",
+				Annotations: map[string]string{
+					"analysisDate": "2022-04-01",
+				},
+				Labels: map[string]string{
+					"app": "example-app",
+				},
+			},
+			Spec: batchv1.CronJobSpec{
+				Schedule:          "*** * * * *",
+				ConcurrencyPolicy: "Allow",
+				JobTemplate: batchv1.JobTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"app": "example-app",
+						},
+					},
+					Spec: batchv1.JobSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "example-container",
+										Image: "nginx",
+									},
+								},
+								RestartPolicy: v1.RestartPolicyOnFailure,
+							},
+						},
+					},
+				},
+			},
+		})
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := CronJobAnalyzer{}
+	analysisResults, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, len(analysisResults), 1)
+	assert.Equal(t, analysisResults[0].Name, "default/example-cronjob")
+	assert.Equal(t, analysisResults[0].Kind, "CronJob")
+}

--- a/pkg/analyzer/deployment.go
+++ b/pkg/analyzer/deployment.go
@@ -23,7 +23,7 @@ func (d DeploymentAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 		"analyzer_name": kind,
 	})
 
-	deployments, err := a.Client.GetClient().AppsV1().Deployments("").List(context.Background(), v1.ListOptions{})
+	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(context.Background(), v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/hpaAnalyzer_test.go
+++ b/pkg/analyzer/hpaAnalyzer_test.go
@@ -204,3 +204,34 @@ func TestHPAAnalyzerWithExistingScaleTargetRef(t *testing.T) {
 		assert.Equal(t, len(analysis.Error), 0)
 	}
 }
+
+func TestHPAAnalyzerNamespaceFiltering(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv1.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+		},
+		&autoscalingv1.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "other-namespace",
+				Annotations: map[string]string{},
+			},
+		})
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+}

--- a/pkg/analyzer/netpol_test.go
+++ b/pkg/analyzer/netpol_test.go
@@ -120,3 +120,77 @@ func TestNetpolWithPod(t *testing.T) {
 
 	assert.Equal(t, len(results), 0)
 }
+
+func TestNetpolNoPodsNamespaceFiltering(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "example",
+					},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "database",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "other-namespace",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "example",
+					},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "database",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := NetworkPolicyAnalyzer{}
+	results, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, len(results), 1)
+	assert.Equal(t, results[0].Kind, "NetworkPolicy")
+
+}

--- a/pkg/analyzer/statefulset_test.go
+++ b/pkg/analyzer/statefulset_test.go
@@ -145,3 +145,33 @@ func TestStatefulSetAnalyzerMissingStorageClass(t *testing.T) {
 	}
 
 }
+
+func TestStatefulSetAnalyzerNamespaceFiltering(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+		},
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "other-namespace",
+			},
+		})
+	statefulSetAnalyzer := StatefulSetAnalyzer{}
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := statefulSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

These changes address an issue with the Cronjob and Deployment analyzers. The `namespace` flag was not being taken into account for these two analyzers, resulting in returning all deployments/cronjobs from all namespaces of a cluster even if the `--namespace` flag was specified.

I took the opportunity to add tests to the existing analyzers to prevent regressions in the future.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->