### PR TITLE
fix: ensure parent directories are created in EnsureDirExists function

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -164,7 +164,7 @@ func FileExists(path string) (bool, error) {
 }
 
 func EnsureDirExists(dir string) error {
-	err := os.Mkdir(dir, 0755)
+	err := os.MkdirAll(dir, 0755)
 
 	if errors.Is(err, os.ErrExist) {
 		return nil


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

The previous implementation of the EnsureDirExists function only created a
single directory, which resulted in an error if the parent directories did
not exist. This fix updates the function to create parent directories
recursively using `os.MkdirAll`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->