### PR TITLE
fix: resolve language toggle bug (issue #294)

### DIFF
--- a/pkg/ai/noopai.go
+++ b/pkg/ai/noopai.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 type NoOpAIClient struct {
@@ -34,7 +35,7 @@ func (a *NoOpAIClient) Parse(ctx context.Context, prompt []string, nocache bool)
 	inputKey := strings.Join(prompt, " ")
 	// Check for cached data
 	sEnc := base64.StdEncoding.EncodeToString([]byte(inputKey))
-	cacheKey := util.GetCacheKey(a.GetName(), sEnc)
+	cacheKey := util.GetCacheKey(a.GetName(), a.language, sEnc)
 
 	response, err := a.GetCompletion(ctx, inputKey)
 	if err != nil {

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -5,8 +5,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"strings"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 
 	"github.com/fatih/color"
 	"github.com/spf13/viper"
@@ -59,7 +60,7 @@ func (a *OpenAIClient) Parse(ctx context.Context, prompt []string, nocache bool)
 	inputKey := strings.Join(prompt, " ")
 	// Check for cached data
 	sEnc := base64.StdEncoding.EncodeToString([]byte(inputKey))
-	cacheKey := util.GetCacheKey(a.GetName(), sEnc)
+	cacheKey := util.GetCacheKey(a.GetName(), a.language, sEnc)
 	// find in viper cache
 	if viper.IsSet(cacheKey) && !nocache {
 		// retrieve data from cache

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -134,8 +134,8 @@ func ReplaceIfMatch(text string, pattern string, replacement string) string {
 	return text
 }
 
-func GetCacheKey(provider string, sEnc string) string {
-	return fmt.Sprintf("%s-%s", provider, sEnc)
+func GetCacheKey(provider string, language string, sEnc string) string {
+	return fmt.Sprintf("%s-%s-%s", provider, language, sEnc)
 }
 
 func GetPodListByLabels(client k.Interface,


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #294 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

The cache key calculation has been updated to include the `language` parameter in addition to the `name` and `sEnc` parameters.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

```bash
(matthisholleville) ➜  k8sgpt git:(main) ✗ ./k8sgpt analyze --namespace k8sgpt --language "english" --explain --no-cache
 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (1/1, 14 it/min)        

0 k8sgpt/fake-hpa(fake-hpa)
- Error: HorizontalPodAutoscaler uses StatefulSet/fake-deployment as ScaleTargetRef which does not exist.
The Kubernetes error message means that the HorizontalPodAutoscaler is referring to a target called "fake-deployment" which does not exist. To fix this error, you need to update the target of the HorizontalPodAutoscaler to refer to a valid deployment or statefulset.

(matthisholleville) ➜  k8sgpt git:(main) ✗ ./k8sgpt analyze --namespace k8sgpt --language "french" --explain            
 100% |███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (1/1, 11 it/min)        

0 k8sgpt/fake-hpa(fake-hpa)
- Error: HorizontalPodAutoscaler uses StatefulSet/fake-deployment as ScaleTargetRef which does not exist.
Le système de gestion de conteneur Kubernetes a rencontré une erreur car il ne trouve pas la cible de mise à l'échelle spécifiée (StatefulSet/fake-deployment) pour le module HorizontalPodAutoscaler. Pour résoudre ce problème, il est nécessaire de vérifier que la cible de mise à l'échelle est correctement spécifiée et existe dans le cluster Kubernetes.

(matthisholleville) ➜  k8sgpt git:(main) ✗ ./k8sgpt analyze --namespace k8sgpt --language "english" --explain
 100% |████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (1/1, 143 it/s)        

0 k8sgpt/fake-hpa(fake-hpa)
- Error: HorizontalPodAutoscaler uses StatefulSet/fake-deployment as ScaleTargetRef which does not exist.
The Kubernetes error message means that the HorizontalPodAutoscaler is referring to a target called "fake-deployment" which does not exist. To fix this error, you need to update the target of the HorizontalPodAutoscaler to refer to a valid deployment or statefulset.
```