### PR TITLE
feat: use OS conform path for storing cached results

### DIFF
--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -15,12 +15,14 @@ package ai
 
 import (
 	"context"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
 )
 
 type IAI interface {
 	Configure(config IAIConfig, language string) error
 	GetCompletion(ctx context.Context, prompt string) (string, error)
-	Parse(ctx context.Context, prompt []string, nocache bool) (string, error)
+	Parse(ctx context.Context, prompt []string, cache cache.ICache) (string, error)
 	GetName() string
 }
 

--- a/pkg/ai/noopai.go
+++ b/pkg/ai/noopai.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
-	"github.com/spf13/viper"
 )
 
 type NoOpAIClient struct {
@@ -44,7 +44,7 @@ func (c *NoOpAIClient) GetCompletion(ctx context.Context, prompt string) (string
 	return response, nil
 }
 
-func (a *NoOpAIClient) Parse(ctx context.Context, prompt []string, nocache bool) (string, error) {
+func (a *NoOpAIClient) Parse(ctx context.Context, prompt []string, cache cache.ICache) (string, error) {
 	// parse the text with the AI backend
 	inputKey := strings.Join(prompt, " ")
 	// Check for cached data
@@ -57,13 +57,13 @@ func (a *NoOpAIClient) Parse(ctx context.Context, prompt []string, nocache bool)
 		return "", err
 	}
 
-	if !viper.IsSet(cacheKey) {
-		viper.Set(cacheKey, base64.StdEncoding.EncodeToString([]byte(response)))
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("error writing config: %v", err)
-			return "", nil
-		}
+  err = cache.Store(cacheKey, base64.StdEncoding.EncodeToString([]byte(response)))
+
+	if err != nil {
+		color.Red("error storing value to cache: %v", err)
+		return "", nil
 	}
+
 	return response, nil
 }
 

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 
 	"github.com/sashabaranov/go-openai"
 
 	"github.com/fatih/color"
-	"github.com/spf13/viper"
 )
 
 type OpenAIClient struct {
@@ -70,15 +70,20 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 	return resp.Choices[0].Message.Content, nil
 }
 
-func (a *OpenAIClient) Parse(ctx context.Context, prompt []string, nocache bool) (string, error) {
+func (a *OpenAIClient) Parse(ctx context.Context, prompt []string, cache cache.ICache) (string, error) {
 	inputKey := strings.Join(prompt, " ")
 	// Check for cached data
 	sEnc := base64.StdEncoding.EncodeToString([]byte(inputKey))
 	cacheKey := util.GetCacheKey(a.GetName(), a.language, sEnc)
 	// find in viper cache
-	if viper.IsSet(cacheKey) && !nocache {
+	if cache.Exists(cacheKey) {
 		// retrieve data from cache
-		response := viper.GetString(cacheKey)
+		response, err := cache.Load(cacheKey)
+
+		if err != nil {
+			return "", err
+		}
+
 		if response == "" {
 			color.Red("error retrieving cached data")
 			return "", nil
@@ -96,13 +101,13 @@ func (a *OpenAIClient) Parse(ctx context.Context, prompt []string, nocache bool)
 		return "", err
 	}
 
-	if !viper.IsSet(cacheKey) || nocache {
-		viper.Set(cacheKey, base64.StdEncoding.EncodeToString([]byte(response)))
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("error writing config: %v", err)
-			return "", nil
-		}
+	err = cache.Store(cacheKey, base64.StdEncoding.EncodeToString([]byte(response)))
+
+	if err != nil {
+		color.Red("error storing value to cache: %v", err)
+		return "", nil
 	}
+
 	return response, nil
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,15 @@
+package cache
+
+type ICache interface {
+	Store(key string, data string) error
+	Load(key string) (string, error)
+	Exists(key string) bool
+}
+
+func New(noCache bool) ICache {
+	if noCache {
+		return &NoopCache{}
+	}
+
+	return &FileBasedCache{}
+}

--- a/pkg/cache/file_based.go
+++ b/pkg/cache/file_based.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/adrg/xdg"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+)
+
+var _ (ICache) = (*FileBasedCache)(nil)
+
+type FileBasedCache struct{}
+
+func (*FileBasedCache) Exists(key string) bool {
+	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "warning: error while testing if cache key exists:", err)
+		return false
+	}
+
+	exists, err := util.FileExists(path)
+
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "warning: error while testing if cache key exists:", err)
+		return false
+	}
+
+	return exists
+}
+
+func (*FileBasedCache) Load(key string) (string, error) {
+	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(path)
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+func (*FileBasedCache) Store(key string, data string) error {
+	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, []byte(data), 0600)
+}

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -1,0 +1,17 @@
+package cache
+
+var _ (ICache) = (*NoopCache)(nil)
+
+type NoopCache struct{}
+
+func (c *NoopCache) Store(key string, data string) error {
+	return nil
+}
+
+func (c *NoopCache) Load(key string) (string, error) {
+	return "", nil
+}
+
+func (c *NoopCache) Exists(key string) bool {
+	return false
+}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #323

## 📑 Description
<!-- Add a brief description of the pr -->
Instead of storing cached values in the config yaml, they are now stored under these OS specific locations:
* Linux: `~/.cache/k8sgpt`
* MacOS: `~/Library/Caches`
* Windows: `%LocalAppData%\cache`

Additionally a `Cache` package and interface has been introduced. Currently there are two implementations:
* Noop - Doesn't do anything
* FileBased - Stores data in files under the locations listed above

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->