### PR TITLE
fix: explicitly pass in filter to async analysis go routine

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -161,7 +161,7 @@ func (a *Analysis) RunAnalysis() []error {
 			if analyzer, ok := analyzerMap[filter]; ok {
 				semaphore <- struct{}{}
 				wg.Add(1)
-				go func(analyzer common.IAnalyzer) {
+				go func(analyzer common.IAnalyzer, filter string) {
 					defer wg.Done()
 					results, err := analyzer.Analyze(analyzerConfig)
 					if err != nil {
@@ -173,7 +173,7 @@ func (a *Analysis) RunAnalysis() []error {
 					a.Results = append(a.Results, results...)
 					mutex.Unlock()
 					<-semaphore
-				}(analyzer)
+				}(analyzer, filter)
 			} else {
 				errorList = append(errorList, fmt.Errorf(fmt.Sprintf("\"%s\" filter does not exist. Please run k8sgpt filters list.", filter)))
 			}
@@ -190,7 +190,7 @@ func (a *Analysis) RunAnalysis() []error {
 		if analyzer, ok := analyzerMap[filter]; ok {
 			semaphore <- struct{}{}
 			wg.Add(1)
-			go func(analyzer common.IAnalyzer) {
+			go func(analyzer common.IAnalyzer, filter string) {
 				defer wg.Done()
 				results, err := analyzer.Analyze(analyzerConfig)
 				if err != nil {
@@ -202,7 +202,7 @@ func (a *Analysis) RunAnalysis() []error {
 				a.Results = append(a.Results, results...)
 				mutex.Unlock()
 				<-semaphore
-			}(analyzer)
+			}(analyzer, filter)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
<!-- Add a brief description of the pr -->
Before the filter inside the func literal was capturing the value from the outer loop. This is a subtle mistake, since in combination with running the function literal as go routine, the value of filter could have already changed at invocation time.

To fix this, the filter is now passed in as an argument to the func literal.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->