### PR TITLE
fix: remove pointer to loop variable when searching the latest event to analyze

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -76,7 +76,11 @@ var ServeCmd = &cobra.Command{
 		if aiProvider == nil {
 			for _, provider := range configAI.Providers {
 				if backend == provider.Name {
-					aiProvider = &provider
+          // he pointer to the range variable is not really an issue here, as there
+          // is a break right after, but to prevent potential future issues, a temp
+          // variable is assigned
+          p := provider
+					aiProvider = &p
 					break
 				}
 			}

--- a/pkg/analyzer/events.go
+++ b/pkg/analyzer/events.go
@@ -36,10 +36,14 @@ func FetchLatestEvent(ctx context.Context, kubernetesClient *kubernetes.Client, 
 	var latestEvent *v1.Event
 	for _, event := range events.Items {
 		if latestEvent == nil {
-			latestEvent = &event
+			// this is required, as a pointer to a loop variable would always yield the latest value in the range
+			e := event
+			latestEvent = &e
 		}
 		if event.LastTimestamp.After(latestEvent.LastTimestamp.Time) {
-			latestEvent = &event
+			// this is required, as a pointer to a loop variable would always yield the latest value in the range
+			e := event
+			latestEvent = &e
 		}
 	}
 	return latestEvent, nil


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
## 📑 Description
Having a pointer to a range variable will always yield the latest value the loop sees. This leads to subtle bugs. To prevent this from happening, the range variable was assigned to a temp variable, which is then referenced as a pointer.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->