### PR TITLE
feat: don't ask for password if backend is localai

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -71,7 +71,7 @@ var AuthCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if password == "" {
+		if ai.NeedPassword(backend) && password == "" {
 			fmt.Printf("Enter %s Key: ", backend)
 			bytePassword, err := term.ReadPassword(int(syscall.Stdin))
 			if err != nil {

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -67,3 +67,7 @@ func (p *AIProvider) GetPassword() string {
 func (p *AIProvider) GetModel() string {
 	return p.Model
 }
+
+func NeedPassword(backend string) bool {
+	return backend != "localai"
+}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Small PR to improve the UX of k8sgpt cli.  
We won't ask for a password in the terminal if backend is localai and password hasn't been set explicitly 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->