### PR TITLE
feat: improve `analyze` command

### DIFF
--- a/pkg/analysis/output.go
+++ b/pkg/analysis/output.go
@@ -58,9 +58,9 @@ func (a *Analysis) textOutput() ([]byte, error) {
 	var output strings.Builder
 	if len(a.Errors) != 0 {
 		output.WriteString("\n")
-		output.WriteString(color.YellowString("Warnings : \n"))
-		for _, aerror := range a.Errors {
-			output.WriteString(fmt.Sprintf("- %s\n", color.YellowString(aerror)))
+		output.WriteString(color.YellowString("Warnings:\n"))
+		for i, aerror := range a.Errors {
+			output.WriteString(fmt.Sprintf("%d. %s\n", i+1, color.YellowString(aerror)))
 		}
 	}
 	output.WriteString("\n")
@@ -69,11 +69,17 @@ func (a *Analysis) textOutput() ([]byte, error) {
 		return []byte(output.String()), nil
 	}
 	for n, result := range a.Results {
-		output.WriteString(fmt.Sprintf("%s %s(%s)\n", color.CyanString("%d", n),
-			color.YellowString(result.Name), color.CyanString(result.ParentObject)))
+		output.WriteString(fmt.Sprintf("\n%s %s", color.CyanString("%d.", n+1),
+			color.YellowString(result.Name)))
+
+		if result.ParentObject != "" {
+			output.WriteString(fmt.Sprintf("(%s)", color.CyanString(result.ParentObject)))
+		}
+
 		for _, err := range result.Error {
 			output.WriteString(fmt.Sprintf("- %s %s\n", color.RedString("Error:"), color.RedString(err.Text)))
 		}
+
 		output.WriteString(color.GreenString(result.Details + "\n"))
 	}
 	return []byte(output.String()), nil


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #332

## 📑 Description
Made the following changes-
- Added `\n` between yellow sections and the top of the yellow GPT response for better readability.
- Made the index start from 1 instead 0 for the results.
- Added index for the errors too.
- Parentheses would be omitted if the value of `result.ParentObject` would be empty.

Here's a reference image for these issues- 
<img width="1788" alt="234235472-8dc723bd-1dea-4666-b99a-630605c54be4" src="https://github.com/k8sgpt-ai/k8sgpt/assets/98955085/b05354b0-d466-415d-b5ff-571d45e88a0d">

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
