### PR TITLE
chore: cleanup duplicated filter logic

### DIFF
--- a/pkg/analysis/analysis_test.go
+++ b/pkg/analysis/analysis_test.go
@@ -14,13 +14,151 @@ limitations under the License.
 package analysis
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"testing"
-
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/magiconair/properties/assert"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"strings"
+	"testing"
 )
+
+// sub-function
+func analysis_RunAnalysis_Filter_Tester(t *testing.T, filterFlag string) []common.Result {
+	clientset := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Status: v1.PodStatus{
+				Phase: v1.PodPending,
+				Conditions: []v1.PodCondition{
+					{
+						Type:    v1.PodScheduled,
+						Reason:  "Unschedulable",
+						Message: "0/1 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.",
+					},
+				},
+			},
+		},
+		&v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+		},
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: v1.ServiceSpec{
+				Selector: map[string]string{
+					"app": "example",
+				},
+			},
+		},
+		&networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+		},
+	)
+
+	analysis := Analysis{
+		Context:        context.Background(),
+		Results:        []common.Result{},
+		Namespace:      "default",
+		MaxConcurrency: 1,
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+	}
+	if len(filterFlag) > 0 {
+		// `--filter` is explicitly given
+		analysis.Filters = strings.Split(filterFlag, ",")
+	}
+	analysis.RunAnalysis()
+	return analysis.Results
+
+}
+
+// Test: Filter logic with running different Analyzers
+func TestAnalysis_RunAnalysis_With_Filter(t *testing.T) {
+	var results []common.Result
+	var filterFlag string
+
+	//1. Neither --filter flag Nor active filter is specified, only the "core analyzers"
+	results = analysis_RunAnalysis_Filter_Tester(t, "")
+	assert.Equal(t, len(results), 3) // all built-in resource will be analyzed
+
+	//2. When the --filter flag is specified
+
+	filterFlag = "Pod" // --filter=Pod
+	results = analysis_RunAnalysis_Filter_Tester(t, filterFlag)
+	assert.Equal(t, len(results), 1)
+	assert.Equal(t, results[0].Kind, filterFlag)
+
+	filterFlag = "Ingress,Pod" // --filter=Ingress,Pod
+	results = analysis_RunAnalysis_Filter_Tester(t, filterFlag)
+	assert.Equal(t, len(results), 2)
+}
+
+// Test:  Filter logic with Active Filter
+func TestAnalysis_RunAnalysis_ActiveFilter(t *testing.T) {
+
+	//When the --filter flag is not specified but has actived filter in config
+	var results []common.Result
+
+	viper.SetDefault("active_filters", "Ingress")
+	results = analysis_RunAnalysis_Filter_Tester(t, "")
+	assert.Equal(t, len(results), 1)
+
+	viper.SetDefault("active_filters", []string{"Ingress", "Service"})
+	results = analysis_RunAnalysis_Filter_Tester(t, "")
+	assert.Equal(t, len(results), 2)
+
+	viper.SetDefault("active_filters", []string{"Ingress", "Service", "Pod"})
+	results = analysis_RunAnalysis_Filter_Tester(t, "")
+	assert.Equal(t, len(results), 3)
+}
+
+// Test: When the --filter flag is not specified but has actived filter in config
+func TestAnalysis_RunAnalysis_ActiveFilter_old(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+		},
+	)
+	analysis := Analysis{
+		Context:        context.Background(),
+		Results:        []common.Result{},
+		Namespace:      "default",
+		MaxConcurrency: 1,
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+	}
+	viper.SetDefault("active_filters", "Ingress")
+	analysis.RunAnalysis()
+	assert.Equal(t, len(analysis.Results), 1)
+}
 
 func TestAnalysis_NoProblemJsonOutput(t *testing.T) {
 
@@ -50,6 +188,7 @@ func TestAnalysis_NoProblemJsonOutput(t *testing.T) {
 	fmt.Println(expected)
 
 	require.Equal(t, got, expected)
+
 }
 
 func TestAnalysis_ProblemJsonOutput(t *testing.T) {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

Clean up duplicated code of original https://github.com/k8sgpt-ai/k8sgpt/blob/main/pkg/analysis/analysis.go#L136 and https://github.com/k8sgpt-ai/k8sgpt/blob/main/pkg/analysis/analysis.go#L161

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

1)I've run `make test` `make fmt` `make lint` `make build` 
2)then run the generated binary with below command:
   `k8sgpt analyze --filter=VulnerabilityReport`
   `k8sgpt analyze`
   the result outputs are the same with released binary from github.

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->