### PR TITLE
chore: make go-lint happy

### DIFF
--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -35,7 +35,7 @@ var AuthCmd = &cobra.Command{
 	Long:  `Provide the necessary credentials to authenticate with your chosen backend.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 	},

--- a/cmd/auth/new.go
+++ b/cmd/auth/new.go
@@ -33,8 +33,8 @@ var newCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		backend, _ := cmd.Flags().GetString("backend")
 		if strings.ToLower(backend) == "azureopenai" {
-			cmd.MarkFlagRequired("engine")
-			cmd.MarkFlagRequired("baseurl")
+			_ = cmd.MarkFlagRequired("engine")
+			_ = cmd.MarkFlagRequired("baseurl")
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/filters/filters.go
+++ b/cmd/filters/filters.go
@@ -25,7 +25,7 @@ var FiltersCmd = &cobra.Command{
 	You can list available filters to analyze resources.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			cmd.Help()
+			_ = cmd.Help()
 			return
 		}
 	},

--- a/cmd/filters/list.go
+++ b/cmd/filters/list.go
@@ -37,7 +37,7 @@ var listCmd = &cobra.Command{
 			activeFilters = coreFilters
 		}
 		inactiveFilters := util.SliceDiff(availableFilters, activeFilters)
-		fmt.Printf(color.YellowString("Active: \n"))
+		fmt.Print(color.YellowString("Active: \n"))
 		for _, filter := range activeFilters {
 
 			// if the filter is an integration, mark this differently
@@ -50,7 +50,7 @@ var listCmd = &cobra.Command{
 
 		// display inactive filters
 		if len(inactiveFilters) != 0 {
-			fmt.Printf(color.YellowString("Unused: \n"))
+			fmt.Print(color.YellowString("Unused: \n"))
 			for _, filter := range inactiveFilters {
 				// if the filter is an integration, mark this differently
 				if util.SliceContainsString(integrationFilters, filter) {

--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -32,7 +32,7 @@ var IntegrationCmd = &cobra.Command{
 	
 	This would allow you to deploy trivy into your cluster and use a K8sGPT analyzer to parse trivy results.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func initConfig() {
 		viper.SetConfigType("yaml")
 		viper.SetConfigName("k8sgpt")
 
-		viper.SafeWriteConfig()
+		_ = viper.SafeWriteConfig()
 	}
 
 	viper.Set("kubecontext", kubecontext)
@@ -96,6 +96,7 @@ func initConfig() {
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
+		_ = 1
 		//	fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 }

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -141,7 +141,7 @@ func (a *Analysis) RunAnalysis() {
 				results, err := analyzer.Analyze(analyzerConfig)
 				if err != nil {
 					mutex.Lock()
-					a.Errors = append(a.Errors, fmt.Sprintf(fmt.Sprintf("[%s] %s", reflect.TypeOf(analyzer).Name(), err)))
+					a.Errors = append(a.Errors, fmt.Sprintf("[%s] %s", reflect.TypeOf(analyzer).Name(), err))
 					mutex.Unlock()
 				}
 				mutex.Lock()
@@ -167,7 +167,7 @@ func (a *Analysis) RunAnalysis() {
 					results, err := analyzer.Analyze(analyzerConfig)
 					if err != nil {
 						mutex.Lock()
-						a.Errors = append(a.Errors, fmt.Sprintf(fmt.Sprintf("[%s] %s", filter, err)))
+						a.Errors = append(a.Errors, fmt.Sprintf("[%s] %s", filter, err))
 						mutex.Unlock()
 					}
 					mutex.Lock()
@@ -176,7 +176,7 @@ func (a *Analysis) RunAnalysis() {
 					<-semaphore
 				}(analyzer, filter)
 			} else {
-				a.Errors = append(a.Errors, fmt.Sprintf(fmt.Sprintf("\"%s\" filter does not exist. Please run k8sgpt filters list.", filter)))
+				a.Errors = append(a.Errors, fmt.Sprintf("\"%s\" filter does not exist. Please run k8sgpt filters list.", filter))
 			}
 		}
 		wg.Wait()
@@ -234,7 +234,7 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 			// FIXME: can we avoid checking if output is json multiple times?
 			//   maybe implement the progress bar better?
 			if output != "json" {
-				bar.Exit()
+				_ = bar.Exit()
 			}
 
 			// Check for exhaustion
@@ -255,7 +255,7 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 
 		analysis.Details = parsedText
 		if output != "json" {
-			bar.Add(1)
+			_ = bar.Add(1)
 		}
 		a.Results[index] = analysis
 	}

--- a/pkg/analyzer/node.go
+++ b/pkg/analyzer/node.go
@@ -58,7 +58,7 @@ func (NodeAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 		}
 
 		if len(failures) > 0 {
-			preAnalysis[fmt.Sprintf("%s", node.Name)] = common.PreAnalysis{
+			preAnalysis[node.Name]= common.PreAnalysis{
 				Node:           node,
 				FailureDetails: failures,
 			}

--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -85,7 +85,7 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 				}
 			} else {
 				// when pod is Running but its ReadinessProbe fails
-				if containerStatus.Ready == false && pod.Status.Phase == "Running" {
+				if !containerStatus.Ready && pod.Status.Phase == "Running" {
 					// parse the event log and append details
 					evt, err := FetchLatestEvent(a.Context, a.Client, pod.Namespace, pod.Name)
 					if err != nil || evt == nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -107,7 +107,7 @@ func (s *Config) healthzHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	fmt.Fprintf(w, string(js))
+	fmt.Fprint(w, string(js))
 }
 
 func getBoolParam(param string) bool {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #404 

## 📑 Description
<!-- Add a brief description of the pr -->

Fix part of the lint errors.
But I didn't fix them all 

(1)Some health relevant code  and unused functions I believe will be refine later by their authors?
(2) For code `cmd/generate/generate.go:43`, I don't understand what it means by `override the default backend if a flag is provided`.


So there are some issues left as below, later when they are all fixed, we can enable lint test in CI as PR Gate:

```
 make lint
INFO [lintersdb] Active 7 linters: [errcheck gosimple govet ineffassign staticcheck typecheck unused]

cmd/generate/generate.go:43:4: ineffectual assignment to backendType (ineffassign)
			backendType = backend
			^
pkg/server/server.go:41:2: field `maxConcurrency` is unused (unused)
	maxConcurrency int
	^
pkg/server/server.go:53:5: var `health` is unused (unused)
var health = Health{
    ^
pkg/server/server.go:104:18: func `(*Config).healthzHandler` is unused (unused)
func (s *Config) healthzHandler(w http.ResponseWriter, r *http.Request) {
                 ^
pkg/server/server.go:113:6: func `getBoolParam` is unused (unused)
func getBoolParam(param string) bool {
     ^
cmd/serve/serve.go:100:20: Error return value of `logger.Sync` is not checked (errcheck)
		defer logger.Sync()
		                 ^
INFO File cache stats: 3 entries of total size 8.9KiB
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->