### PR TITLE
fix: missing validation for backend option in remove command

### DIFF
--- a/cmd/auth/remove.go
+++ b/cmd/auth/remove.go
@@ -32,6 +32,11 @@ var removeCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		if backend == "" {
+			color.Red("Error: --backend option must be set.")
+			os.Exit(1)
+		}
+
 		foundBackend := false
 		for i, provider := range configAI.Providers {
 			if backend == provider.Name {
@@ -55,5 +60,5 @@ var removeCmd = &cobra.Command{
 
 func init() {
 	// add flag for backend
-	removeCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
+	removeCmd.Flags().StringVarP(&backend, "backend", "b", "", "Backend AI provider")
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

The commit fixes an issue where the `--backend` option was not properly validated in the `remove` command.

Previously, the command did not check if the `--backend` option was set, leading to potential errors. This fix ensures that the option is required and throws an error if it is missing.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->