### PR TITLE
fix: show real version in k8sgpt version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ k8sgpt*
 !charts/k8sgpt
 *.vscode
 dist/
+version.md
 
 bin/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,10 @@ all: tidy add-copyright lint cover build
 
 ## build: Build binaries by default
 .PHONY: build
-build: 
+versionfile:
+	@echo $(VERSION) > version.md
+
+build: versionfile 
 	@echo "$(shell go version)"
 	@echo "===========> Building binary $(BUILDAPP) *[Git Info]: $(VERSION)-$(GIT_COMMIT)"
 	@export CGO_ENABLED=0 && go build -o $(BUILDAPP) -ldflags '-s -w' $(BUILDFILE)
@@ -81,7 +84,7 @@ undeploy: helm
 
 ## docker-build: Build docker image
 .PHONY: docker-build
-docker-build:
+docker-build: versionfile
 	@echo "===========> Building docker image"
 	docker buildx build --build-arg=VERSION="$$(git describe --tags --abbrev=0)" --build-arg=COMMIT="$$(git rev-parse --short HEAD)" --build-arg DATE="$$(date +%FT%TZ)" --platform="linux/amd64,linux/arm64" -t ${IMG} -f container/Dockerfile . --push
 
@@ -106,7 +109,7 @@ style: fmt vet lint
 
 ## test: Run unit test
 .PHONY: test
-test: 
+test: versionfile 
 	@echo "===========> Run unit test"
 	@$(GO) test ./... 
 
@@ -120,6 +123,7 @@ cover: test
 clean:
 	@echo "===========> Cleaning all builds OUTPUT_DIR($(OUTPUT_DIR))"
 	@-rm -vrf $(OUTPUT_DIR)
+	@-rm -f version.md
 	@echo "===========> End clean..."
 
 ## help: Show this help info.

--- a/main.go
+++ b/main.go
@@ -13,9 +13,13 @@ limitations under the License.
 
 package main
 
-import "github.com/k8sgpt-ai/k8sgpt/cmd"
+import (
+	_ "embed"
+	"github.com/k8sgpt-ai/k8sgpt/cmd"
+)
 
-var version = "dev"
+//go:embed version.md
+var version string
 
 func main() {
 	cmd.Execute(version)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # NA

so far , `k8sgpt version` always show `dev`

## 📑 Description

when `make` , a `version.md` will show up, then using golang `embed` to load it.


test result:
```
./bin/k8sgpt version
k8sgpt version v0.3.2
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->