### PR TITLE
fix: name of sa reference in deployment

### DIFF
--- a/charts/k8sgpt/templates/deployment.yaml
+++ b/charts/k8sgpt/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/name: {{ include "k8sgpt.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: k8sgpt
+      serviceAccountName: {{ template "k8sgpt.fullname" . }}
       containers:
       - name: k8sgpt-container
         imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
While the name in the ServiceAccount ressource is "k8sgpt.fullname", the reference in the deployment is hardcoded "k8sgpt". If you install the helm chart with a different release name than "k8sgpt", the deployment won't start because the SA "k8sgpt" is not found.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->