### PR TITLE
feat: analyze specific resource(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ _Filter by namespace_
 k8sgpt analyze --explain --filter=Pod --namespace=default
 ```
 
+_Analyze specific resources_
+```
+k8sgpt analyze pod/nginx-7b6fc59cd6-shz7h service/nginx  -n default --explain
+```
+
+_Analyze specific resources with filter_
+```
+k8sgpt analyze nginx-7b6fc59cd6-shz7h nginx-7db4cf8964-b26wf -n default --filter=Pod
+```
+
 _Output to JSON_
 
 ```

--- a/cmd/auth/remove.go
+++ b/cmd/auth/remove.go
@@ -68,4 +68,3 @@ var removeCmd = &cobra.Command{
 func init() {
 
 }
-

--- a/cmd/cache/list.go
+++ b/cmd/cache/list.go
@@ -42,7 +42,7 @@ var listCmd = &cobra.Command{
 			color.Red("Error: %v", err)
 			os.Exit(1)
 		}
-		
+
 		for _, name := range names {
 			println(name)
 		}

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -47,6 +47,7 @@ type Analysis struct {
 	MaxConcurrency     int
 	AnalysisAIProvider string // The name of the AI Provider used for this analysis
 	WithDoc            bool
+	SpecificResources  []string // format: slices of <kind>/<name> or just <name>
 }
 
 type AnalysisStatus string
@@ -65,7 +66,7 @@ type JsonOutput struct {
 	Results  []common.Result `json:"results"`
 }
 
-func NewAnalysis(backend string, language string, filters []string, namespace string, noCache bool, explain bool, maxConcurrency int, withDoc bool) (*Analysis, error) {
+func NewAnalysis(backend string, language string, filters []string, namespace string, noCache bool, explain bool, maxConcurrency int, withDoc bool, specificResources []string) (*Analysis, error) {
 	var configAI ai.AIConfiguration
 	err := viper.UnmarshalKey("ai", &configAI)
 	if err != nil {
@@ -131,6 +132,7 @@ func NewAnalysis(backend string, language string, filters []string, namespace st
 		MaxConcurrency:     maxConcurrency,
 		AnalysisAIProvider: backend,
 		WithDoc:            withDoc,
+		SpecificResources:  specificResources,
 	}, nil
 }
 
@@ -139,6 +141,54 @@ func (a *Analysis) RunAnalysis() {
 
 	coreAnalyzerMap, analyzerMap := analyzer.GetAnalyzerMap()
 
+	// validate the specificResources
+	resourceMap := make(map[string][]string)
+	// --------------
+	// Rule:
+	//    The specific resource arguments can be below situations :
+	//    (1)  "pod/<podName>, service/<svcName>, .."
+	//
+	//           NOTE: when --filter specifies ONLY one kind of filter, example , --filters=Pod, then above resource "service/<svcName>" will be omitted
+
+	//    (2)  "<name1>, <name2>, .."
+	//
+	//           NOTE: it's ONLY valid when `--filter` specifies ONLY one kind of filter, to avoid ambiguity.
+	//                 example, --filters=Pod    ,     ALL of the resource names will be treated as "Pod"
+	//                 example, --filters=Ingress,     ALL of the resource names will be treated as "Ingress"
+	//                 example, --filters=Pod,Ingress, those no-kind resources will be treated as INVALID
+	//                 example, --filters=<blank>,     those no-kind resources will be treated as INVALID
+
+	//
+
+	for _, resource := range a.SpecificResources {
+		if strings.Count(resource, "/") == 0 {
+			// no-kind resources
+			if len(a.Filters) == 1 {
+				filterflag := a.Filters[0]
+				resourceMap[filterflag] = append(resourceMap[filterflag], resource)
+			} else {
+				//  no-kind resources is ONLY allowed when `--filter` arg number == 1.
+				a.Errors = append(a.Errors, fmt.Sprintf("Error: wrong argument: kubernetes resource format should be <kind>/<pod>, but given: %v", resource))
+				return
+			}
+		} else {
+			pair := strings.Split(resource, "/") // Split "pod/busybox" into "<kind>:<name>" pair
+			// verify the kind is supported (in analyzerMap)
+			matched := false
+			for k, _ := range analyzerMap {
+				if strings.EqualFold(pair[0], k) {
+					matched = true
+					pair[0] = k // to align the capitalization
+					break
+				}
+			}
+			if !matched {
+				a.Errors = append(a.Errors, fmt.Sprintf("Error: wrong argument: unrecognized kubernetes resource given: %v", resource))
+				return
+			}
+			resourceMap[pair[0]] = append(resourceMap[pair[0]], pair[1])
+		}
+	}
 	// we get the openapi schema from the server only if required by the flag "with-doc"
 	openapiSchema := &openapi_v2.Document{}
 	if a.WithDoc {
@@ -157,13 +207,26 @@ func (a *Analysis) RunAnalysis() {
 		AIClient:      a.AIClient,
 		OpenapiSchema: openapiSchema,
 	}
+	analyzerConfig.Resources = make(map[string][]string)
+	for k, v := range resourceMap {
+		analyzerConfig.Resources[k] = v
+	}
+	if len(analyzerConfig.Resources) > 0 && len(analyzerConfig.Namespace) == 0 {
+		analyzerConfig.Namespace = "default" // to avoid "an empty namespace may not be set when a resource name is provided"
+	}
 
 	semaphore := make(chan struct{}, a.MaxConcurrency)
 	// if there are no filters selected and no active_filters then run coreAnalyzer
 	if len(a.Filters) == 0 && len(activeFilters) == 0 {
 		var wg sync.WaitGroup
 		var mutex sync.Mutex
-		for _, analyzer := range coreAnalyzerMap {
+		for k, analyzer := range coreAnalyzerMap {
+			if len(analyzerConfig.Resources) > 0 {
+				if _, ok := analyzerConfig.Resources[k]; !ok {
+					// NOTE: if specific resources given(example: pod/nginx), the other analyzer(like deploy/svc) can be skipped
+					continue
+				}
+			}
 			wg.Add(1)
 			semaphore <- struct{}{}
 			go func(analyzer common.IAnalyzer, wg *sync.WaitGroup, semaphore chan struct{}) {
@@ -190,6 +253,12 @@ func (a *Analysis) RunAnalysis() {
 		var wg sync.WaitGroup
 		var mutex sync.Mutex
 		for _, filter := range a.Filters {
+			if len(analyzerConfig.Resources) > 0 {
+				if _, ok := analyzerConfig.Resources[filter]; !ok {
+					// NOTE: if specific resources given(example: pod/nginx), the other analyzer(like deploy/svc) can be skipped
+					continue
+				}
+			}
 			if analyzer, ok := analyzerMap[filter]; ok {
 				semaphore <- struct{}{}
 				wg.Add(1)
@@ -219,6 +288,12 @@ func (a *Analysis) RunAnalysis() {
 	semaphore = make(chan struct{}, a.MaxConcurrency)
 	// use active_filters
 	for _, filter := range activeFilters {
+		if len(analyzerConfig.Resources) > 0 {
+			if _, ok := analyzerConfig.Resources[filter]; !ok {
+				// NOTE: if specific resources given(example: pod/nginx), the other analyzer(like deploy/svc) can be skipped
+				continue
+			}
+		}
 		if analyzer, ok := analyzerMap[filter]; ok {
 			semaphore <- struct{}{}
 			wg.Add(1)

--- a/pkg/analysis/analysis_test.go
+++ b/pkg/analysis/analysis_test.go
@@ -31,24 +31,32 @@ import (
 )
 
 // sub-function
-func analysis_RunAnalysisFilterTester(t *testing.T, filterFlag string) []common.Result {
-	clientset := fake.NewSimpleClientset(
-		&v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "example",
-				Namespace: "default",
-			},
-			Status: v1.PodStatus{
-				Phase: v1.PodPending,
-				Conditions: []v1.PodCondition{
-					{
-						Type:    v1.PodScheduled,
-						Reason:  "Unschedulable",
-						Message: "0/1 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.",
-					},
+func badPod(name string, namespace string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodPending,
+			Conditions: []v1.PodCondition{
+				{
+					Type:    v1.PodScheduled,
+					Reason:  "Unschedulable",
+					Message: "0/1 nodes are available: 1 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.",
 				},
 			},
 		},
+	}
+
+}
+
+// sub-function
+func analysis_RunAnalysisFilterTester(t *testing.T, filterFlag string, specificResources []string) []common.Result {
+
+	clientset := fake.NewSimpleClientset(
+		badPod("example1", "default"),
+		badPod("example2", "default"),
 		&v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "example",
@@ -78,10 +86,11 @@ func analysis_RunAnalysisFilterTester(t *testing.T, filterFlag string) []common.
 	)
 
 	analysis := Analysis{
-		Context:        context.Background(),
-		Results:        []common.Result{},
-		Namespace:      "default",
-		MaxConcurrency: 1,
+		Context:           context.Background(),
+		Results:           []common.Result{},
+		Namespace:         "default",
+		MaxConcurrency:    1,
+		SpecificResources: specificResources,
 		Client: &kubernetes.Client{
 			Client: clientset,
 		},
@@ -101,19 +110,19 @@ func TestAnalysis_RunAnalysisWithFilter(t *testing.T) {
 	var filterFlag string
 
 	//1. Neither --filter flag Nor active filter is specified, only the "core analyzers"
-	results = analysis_RunAnalysisFilterTester(t, "")
-	assert.Equal(t, len(results), 3) // all built-in resource will be analyzed
+	results = analysis_RunAnalysisFilterTester(t, "", []string{})
+	assert.Equal(t, len(results), 4) // all built-in resource will be analyzed
 
 	//2. When the --filter flag is specified
 
 	filterFlag = "Pod" // --filter=Pod
-	results = analysis_RunAnalysisFilterTester(t, filterFlag)
-	assert.Equal(t, len(results), 1)
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{})
+	assert.Equal(t, len(results), 2)
 	assert.Equal(t, results[0].Kind, filterFlag)
 
 	filterFlag = "Ingress,Pod" // --filter=Ingress,Pod
-	results = analysis_RunAnalysisFilterTester(t, filterFlag)
-	assert.Equal(t, len(results), 2)
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{})
+	assert.Equal(t, len(results), 3)
 }
 
 // Test:  Filter logic with Active Filter
@@ -123,16 +132,73 @@ func TestAnalysis_RunAnalysisActiveFilter(t *testing.T) {
 	var results []common.Result
 
 	viper.SetDefault("active_filters", "Ingress")
-	results = analysis_RunAnalysisFilterTester(t, "")
+	results = analysis_RunAnalysisFilterTester(t, "", []string{})
 	assert.Equal(t, len(results), 1)
 
 	viper.SetDefault("active_filters", []string{"Ingress", "Service"})
-	results = analysis_RunAnalysisFilterTester(t, "")
+	results = analysis_RunAnalysisFilterTester(t, "", []string{})
 	assert.Equal(t, len(results), 2)
 
 	viper.SetDefault("active_filters", []string{"Ingress", "Service", "Pod"})
-	results = analysis_RunAnalysisFilterTester(t, "")
+	results = analysis_RunAnalysisFilterTester(t, "", []string{})
+	assert.Equal(t, len(results), 4)
+}
+
+// Test: test specific resources
+func TestAnalysis_RunAnalysisWithSpecificRes_No_Filter(t *testing.T) {
+	var results []common.Result
+
+	viper.SetDefault("active_filters", []string{})
+	// 1. one specific resource
+	results = analysis_RunAnalysisFilterTester(t, "", []string{"pod/example1"})
+	assert.Equal(t, len(results), 1)
+
+	// 2. multiple specific resources
+	results = analysis_RunAnalysisFilterTester(t, "", []string{"pod/example1", "service/example"})
+	assert.Equal(t, len(results), 2)
+	results = analysis_RunAnalysisFilterTester(t, "", []string{"pod/example1", "pod/example2", "service/example"})
 	assert.Equal(t, len(results), 3)
+
+	// 3. resource not found
+	results = analysis_RunAnalysisFilterTester(t, "", []string{"pod/not-exist"})
+	assert.Equal(t, len(results), 0)
+}
+
+// Test: test specific resources + filter
+func TestAnalysis_RunAnalysisWithSpecificRes_With_Filter(t *testing.T) {
+	var results []common.Result
+	var filterFlag string
+	// both `--filters` and specific resources are given
+
+	// 4. single filter flag
+	filterFlag = "Pod"
+	//   4.1) non-kind resource
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"example1", "example2"})
+	assert.Equal(t, len(results), 2)
+	//   4.2) resource kind matches filter
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"pod/example1", "pod/example2"})
+	assert.Equal(t, len(results), 2)
+	//   4.3) resource kind not match filter, will be omitted
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"pod/example1", "service/example"})
+	assert.Equal(t, len(results), 1)
+
+	// 5. multiple filter flags
+	filterFlag = "Pod,Service"
+	//  5.1) kinds are all aligned
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"pod/example1", "pod/example2", "service/example"})
+	assert.Equal(t, len(results), 3)
+	//  5.2) some kinds are not aligned
+	filterFlag = "Pod,Service,Deployment"
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"pod/example1", "pod/example2", "service/example"})
+	assert.Equal(t, len(results), 3)
+
+	// 6. invalid argument ( multiple filter flags but resources have no kind prefix)
+	filterFlag = "Pod,Service"
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"example1"})
+	assert.Equal(t, len(results), 0)
+	results = analysis_RunAnalysisFilterTester(t, filterFlag, []string{"ping", "pong"})
+	assert.Equal(t, len(results), 0)
+
 }
 
 func TestAnalysis_NoProblemJsonOutput(t *testing.T) {

--- a/pkg/analyzer/service.go
+++ b/pkg/analyzer/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -42,10 +43,21 @@ func (ServiceAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 		"analyzer_name": kind,
 	})
 
-	// search all namespaces for pods that are not running
-	list, err := a.Client.GetClient().CoreV1().Endpoints(a.Namespace).List(a.Context, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
+	var list *corev1.EndpointsList = &corev1.EndpointsList{}
+	if len(a.Resources["Service"]) > 0 {
+		for _, name := range a.Resources["Service"] {
+			ep, err := a.Client.GetClient().CoreV1().Endpoints(a.Namespace).Get(a.Context, name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			list.Items = append(list.Items, *ep)
+		}
+	} else {
+		var err error
+		list, err = a.Client.GetClient().CoreV1().Endpoints(a.Namespace).List(a.Context, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var preAnalysis = map[string]common.PreAnalysis{}

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -35,6 +35,7 @@ type Analyzer struct {
 	Client        *kubernetes.Client
 	Context       context.Context
 	Namespace     string
+	Resources     map[string][]string // when specific resources to be analyzed, e.g.: map["Pod"]={"mysql","nginx"}
 	AIClient      ai.IAI
 	PreAnalysis   map[string]PreAnalysis
 	Results       []Result

--- a/pkg/server/analyze.go
+++ b/pkg/server/analyze.go
@@ -33,6 +33,7 @@ func (h *handler) Analyze(ctx context.Context, i *schemav1.AnalyzeRequest) (
 		i.Explain,
 		int(i.MaxConcurrency),
 		false, // Kubernetes Doc disabled in server mode
+		[]string{},
 	)
 	if err != nil {
 		return &schemav1.AnalyzeResponse{}, err


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #285 

## 📑 Description

add capability to analyze specific resource(s)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

### Design Overview and Demo:
The usage is similar as `kubectl get xxx` ( one resource or multiple resource, but should be in the same namespaces(for namespaced-scope resources))
But note: it doesn't support k8s short-name so far ( like `service` -> `svc`).

### Example 1:
```
k8sgpt  analyze -n default  pod/deployment003-74db995cbd-m2t8x
```
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/e5e21720-f0ad-4cc0-9ccd-f71f7ba03992)


### Example 2:

just like kubectl can do `kubectl get deployment/deployment003  service/mysql-service`, 

multiple resources are analyzed

```
k8sgpt  analyze deployment/deployment003  service/mysql-service
```
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/a00ef9fa-fb47-401d-a7e1-a834605ac01b)


### Example 3:

co-work with filter: `filter` takes priority and find the overlap.

```
k8sgpt  analyze  deployment/deployment003  service/mysql-service --filter=Deployment
```

![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/157da581-ce3a-448e-8aca-7572ed223db4)


### Example 4:

specific resource not existing

![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/2f454c18-6dc6-4900-bccf-41207615f14f)


### More

add example in `-h`
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/93d67379-a005-4dfb-a307-1e192025c693)





### Additional Changes:

- when `no namespace` is given, "default" will be filled automatically.
- add example in cmd helper

