### PR TITLE
fix: 'intergration' typos

### DIFF
--- a/cmd/integration/integration.go
+++ b/cmd/integration/integration.go
@@ -25,8 +25,8 @@ var (
 var IntegrationCmd = &cobra.Command{
 	Use:     "integration",
 	Aliases: []string{"integrations"},
-	Short:   "Intergrate another tool into K8sGPT",
-	Long: `Intergrate another tool into K8sGPT. For example:
+	Short:   "Integrate another tool into K8sGPT",
+	Long: `Integrate another tool into K8sGPT. For example:
 	
 	k8sgpt integration activate trivy
 	

--- a/pkg/ai/prompts.go
+++ b/pkg/ai/prompts.go
@@ -11,5 +11,5 @@ const (
 
 var PromptMap = map[string]string{
 	"default":             default_prompt,
-	"VulnerabilityReport": trivy_prompt, // for Trivy intergration, the key should match `Result.Kind` in pkg/common/types.go
+	"VulnerabilityReport": trivy_prompt, // for Trivy integration, the key should match `Result.Kind` in pkg/common/types.go
 }


### PR DESCRIPTION
## 📑 Description
Fixes `intergration` typos in CLI help text

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
