### PR TITLE
fix: add --no-install for activate command

### DIFF
--- a/cmd/cache/list.go
+++ b/cmd/cache/list.go
@@ -42,7 +42,7 @@ var listCmd = &cobra.Command{
 			color.Red("Error: %v", err)
 			os.Exit(1)
 		}
-		
+
 		for _, name := range names {
 			println(name)
 		}

--- a/cmd/integration/activate.go
+++ b/cmd/integration/activate.go
@@ -21,6 +21,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+var (
+	skipInstall bool
+)
+
 // activateCmd represents the activate command
 var activateCmd = &cobra.Command{
 	Use:   "activate [integration]",
@@ -39,7 +43,7 @@ var activateCmd = &cobra.Command{
 
 		integration := integration.NewIntegration()
 		// Check if the integation exists
-		err := integration.Activate(integrationName, namespace, activeFilters)
+		err := integration.Activate(integrationName, namespace, activeFilters, skipInstall)
 		if err != nil {
 			color.Red("Error: %v", err)
 			return
@@ -51,5 +55,6 @@ var activateCmd = &cobra.Command{
 
 func init() {
 	IntegrationCmd.AddCommand(activateCmd)
+	activateCmd.Flags().BoolVarP(&skipInstall, "no-install", "s", false, "Only activate the integration filter without installing the filter (for example, if that filter plugin is already deployed in cluster, we do not need to re-install it again)")
 
 }

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -66,7 +66,7 @@ func (*Integration) Get(name string) (IIntegration, error) {
 	return integrations[name], nil
 }
 
-func (*Integration) Activate(name string, namespace string, activeFilters []string) error {
+func (*Integration) Activate(name string, namespace string, activeFilters []string, skipInstall bool) error {
 	if _, ok := integrations[name]; !ok {
 		return errors.New("integration not found")
 	}
@@ -83,8 +83,10 @@ func (*Integration) Activate(name string, namespace string, activeFilters []stri
 
 	viper.Set("active_filters", uniqueFilters)
 
-	if err := integrations[name].Deploy(namespace); err != nil {
-		return err
+	if !skipInstall {
+		if err := integrations[name].Deploy(namespace); err != nil {
+			return err
+		}
 	}
 
 	if err := viper.WriteConfig(); err != nil {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #534

Use Case:
This flag is helpful, for example, I ran `k8sgpt` command in local machine, but the k8s cluster runs remotely.
I've activated the plugin remotely, but local k8sgpt.conf didn't reflect it.
so this flag helps my local config file to catch up the real situation.


## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [] My code requires changes to the documentation
- [] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

### Demo :

(1) Before `activate trivy`: 
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/579ddb34-0c94-4aef-afc2-24764d5d583a)

(2) helper message:
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/2fae0cdc-ec03-4deb-98d4-1787ce59d356)

(3) activate without install it
![image](https://github.com/k8sgpt-ai/k8sgpt/assets/14049268/7d6d4e4a-aee8-4d8e-935c-6920efcd29e1)
