### PR TITLE
fix: update `add.go`

### DIFF
--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -114,9 +114,9 @@ var addCmd = &cobra.Command{
 
 func init() {
 	// add flag for backend
-	addCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
+	addCmd.Flags().StringVarP(&backend, "backend", "b", "", "Backend AI provider")
 	// add flag for model
-	addCmd.Flags().StringVarP(&model, "model", "m", "gpt-3.5-turbo", "Backend AI model")
+	addCmd.Flags().StringVarP(&model, "model", "m", "", "Backend AI model")
 	// add flag for password
 	addCmd.Flags().StringVarP(&password, "password", "p", "", "Backend AI password")
 	// add flag for url

--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -9,7 +9,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-*/
+*/ 
 
 package auth
 


### PR DESCRIPTION
This PR fixes: #596 

`default "gpt-3.5-turbo"` and `default "open ai"` were removed from the description.

Before
![Screenshot from 2023-08-14 19-59-13](https://github.com/k8sgpt-ai/k8sgpt/assets/101946115/e3896f98-9bd5-420d-845d-26eda5be9361)

After
![Screenshot from 2023-08-14 19-59-59](https://github.com/k8sgpt-ai/k8sgpt/assets/101946115/f7ad06d7-6dc9-4264-81db-434277b0bfd1)
