### PR TITLE
fix: use-case while in cluster, connecting to an external

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -37,7 +37,7 @@ func (c *Client) GetRestClient() rest.Interface {
 func NewClient(kubecontext string, kubeconfig string) (*Client, error) {
 	var config *rest.Config
 	config, err := rest.InClusterConfig()
-	if err != nil {
+	if kubeconfig != "" || err != nil {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 
 		if kubeconfig != "" {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #604 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
There is a use case where people will run k8sgpt within a _management_ cluster, as a pivot to other clusters where they can define explicitly the kubeconfig. 
This small PR hopefully addresses that case by ensuring whenever `kubeconfig` is defined we will use it to create the k8s client even if k8sgpt is running in a cluster

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->