### PR TITLE
feat: show each ConfigAuditReport check

### DIFF
--- a/pkg/ai/prompts.go
+++ b/pkg/ai/prompts.go
@@ -6,10 +6,12 @@ const (
 	Error: {Explain error here}
 	Solution: {Step by step solution here}
 	`
-	trivy_prompt = "Explain the following trivy scan result and the detail risk or root cause of the CVE ID, then provide a solution. Response in %s: %s"
+	trivy_vuln_prompt = "Explain the following trivy scan result and the detail risk or root cause of the CVE ID, then provide a solution. Response in %s: %s"
+	trivy_conf_prompt = "Explain the following trivy scan result and the detail risk or root cause of the security check, then provide a solution."
 )
 
 var PromptMap = map[string]string{
 	"default":             default_prompt,
-	"VulnerabilityReport": trivy_prompt, // for Trivy integration, the key should match `Result.Kind` in pkg/common/types.go
+	"VulnerabilityReport": trivy_vuln_prompt, // for Trivy integration, the key should match `Result.Kind` in pkg/common/types.go
+	"ConfigAuditReport":   trivy_conf_prompt,
 }

--- a/pkg/integration/trivy/analyzer.go
+++ b/pkg/integration/trivy/analyzer.go
@@ -118,8 +118,17 @@ func (t TrivyAnalyzer) analyzeConfigAuditReports(a common.Analyzer) ([]common.Re
 		for _, check := range report.Report.Checks {
 			if check.Severity == "MEDIUM" || check.Severity == "HIGH" || check.Severity == "CRITICAL" {
 				failures = append(failures, common.Failure{
-					Text:      fmt.Sprintf("Config issue with severity \"%s\" found: %s", check.Severity, strings.Join(check.Messages, "")),
-					Sensitive: []common.Sensitive{},
+					Text: fmt.Sprintf("Config issue with severity \"%s\" found: %s", check.Severity, strings.Join(check.Messages, "")),
+					Sensitive: []common.Sensitive{
+						{
+							Unmasked: report.Labels["trivy-operator.resource.name"],
+							Masked:   util.MaskString(report.Labels["trivy-operator.resource.name"]),
+						},
+						{
+							Unmasked: report.Labels["trivy-operator.resource.namespace"],
+							Masked:   util.MaskString(report.Labels["trivy-operator.resource.namespace"]),
+						},
+					},
 				})
 			}
 		}

--- a/pkg/integration/trivy/analyzer.go
+++ b/pkg/integration/trivy/analyzer.go
@@ -15,6 +15,7 @@ package trivy
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/trivy-operator/pkg/apis/aquasecurity/v1alpha1"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -89,7 +90,7 @@ func (TrivyAnalyzer) analyzeVulnerabilityReports(a common.Analyzer) ([]common.Re
 }
 
 func (t TrivyAnalyzer) analyzeConfigAuditReports(a common.Analyzer) ([]common.Result, error) {
-	// Get all trivy VulnerabilityReports
+	// Get all trivy ConfigAuditReports
 	result := &v1alpha1.ConfigAuditReportList{}
 
 	config := a.Client.GetConfig()
@@ -112,15 +113,17 @@ func (t TrivyAnalyzer) analyzeConfigAuditReports(a common.Analyzer) ([]common.Re
 
 	for _, report := range result.Items {
 
+		// For each k8s resources there may be multiple checks
 		var failures []common.Failure
-		if report.Report.Summary.HighCount > 0 {
-
-			failures = append(failures, common.Failure{
-				Text:      fmt.Sprintf("Config audit report %s detected at least one high issue", report.Name),
-				Sensitive: []common.Sensitive{},
-			})
-
+		for _, check := range report.Report.Checks {
+			if check.Severity == "MEDIUM" || check.Severity == "HIGH" || check.Severity == "CRITICAL" {
+				failures = append(failures, common.Failure{
+					Text:      fmt.Sprintf("Config issue with severity \"%s\" found: %s", check.Severity, strings.Join(check.Messages, "")),
+					Sensitive: []common.Sensitive{},
+				})
+			}
 		}
+
 		if len(failures) > 0 {
 			preAnalysis[fmt.Sprintf("%s/%s", report.Labels["trivy-operator.resource.namespace"],
 				report.Labels["trivy-operator.resource.name"])] = common.PreAnalysis{


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #590

## 📑 Description
in addition to #609 we should show each check of the ConfigAuditReport similar to the VulnerabilityReport. Then the user gets more insights what the security issues are and also the AI can give you better solutions.

Also, I added a specific AI prompt for the ConfigAuditReport kind to get better AI results.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->