### PR TITLE
fix: defer to service analyser when selectors are missing

### DIFF
--- a/pkg/analyzer/mutating_webhook.go
+++ b/pkg/analyzer/mutating_webhook.go
@@ -78,6 +78,10 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 				continue
 			}
 
+			// When Service selectors are empty we defer to service analyser
+			if len(service.Spec.Selector) == 0 {
+				continue
+			}
 			// Get pods within service
 			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),

--- a/pkg/analyzer/validating_webhook.go
+++ b/pkg/analyzer/validating_webhook.go
@@ -76,6 +76,10 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 				continue
 			}
 
+			// When Service selectors are empty we defer to service analyser
+			if len(service.Spec.Selector) == 0 {
+				continue
+			}
 			// Get pods within service
 			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #647  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR fixes potential panic issues when service selector is empty for a service defined in {mutating,validating} webhook K8s resources.
It will now continue on their absence and effectively defer the analysis to the service analyser.
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->