### PR TITLE
feat: add cronjob max time threshold

### DIFF
--- a/pkg/analyzer/cronjob_test.go
+++ b/pkg/analyzer/cronjob_test.go
@@ -15,7 +15,10 @@ package analyzer
 
 import (
 	"context"
+	"fmt"
+	"github.com/spf13/viper"
 	"testing"
+	"time"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
@@ -230,4 +233,219 @@ func TestCronJobBrokenMultipleNamespaceFiltering(t *testing.T) {
 	assert.Equal(t, len(analysisResults), 1)
 	assert.Equal(t, analysisResults[0].Name, "default/example-cronjob")
 	assert.Equal(t, analysisResults[0].Kind, "CronJob")
+}
+
+func TestCronJobRunningTimeExceedMaxTime(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-cronjob",
+			Namespace: "default",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "*/1 * * * *",
+			ConcurrencyPolicy: "Allow",
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "example-app",
+					},
+				},
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "example-container",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: batchv1.CronJobStatus{
+			Active: []v1.ObjectReference{
+				{
+					Kind:      "Job",
+					Namespace: "default",
+					Name:      "example-cronjob-1637931600",
+				},
+			},
+		},
+	},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-cronjob-1637931600-abcde",
+				Namespace: "default",
+				Labels: map[string]string{
+					"job-name": "example-cronjob-1637931600",
+				},
+			},
+			Status: v1.PodStatus{
+				StartTime: &metav1.Time{
+					Time: time.Now().Add(-time.Hour * 2),
+				},
+			},
+		},
+	)
+	viper.Set("cronjobMaxTime", "1h")
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := CronJobAnalyzer{}
+	analysisResults, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(analysisResults)
+	assert.Equal(t, len(analysisResults), 1)
+}
+
+func TestCronJobRunningTimeNotExceedMaxTime(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-cronjob",
+			Namespace: "default",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "*/1 * * * *",
+			ConcurrencyPolicy: "Allow",
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "example-app",
+					},
+				},
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "example-container",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: batchv1.CronJobStatus{
+			Active: []v1.ObjectReference{
+				{
+					Kind:      "Job",
+					Namespace: "default",
+					Name:      "example-cronjob-1637931600",
+				},
+			},
+		},
+	},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-cronjob-1637931600-abcde",
+				Namespace: "default",
+				Labels: map[string]string{
+					"job-name": "example-cronjob-1637931600",
+				},
+			},
+			Status: v1.PodStatus{
+				StartTime: &metav1.Time{
+					Time: time.Now().Add(-time.Hour * 2),
+				},
+			},
+		},
+	)
+
+	viper.Set("cronjobMaxTime", "3h")
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := CronJobAnalyzer{}
+	analysisResults, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
+}
+
+func TestCronJobRunningNoMaxTimeFlag(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example-cronjob",
+			Namespace: "default",
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:          "*/1 * * * *",
+			ConcurrencyPolicy: "Allow",
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "example-app",
+					},
+				},
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "example-container",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: batchv1.CronJobStatus{
+			Active: []v1.ObjectReference{
+				{
+					Kind:      "Job",
+					Namespace: "default",
+					Name:      "example-cronjob-1637931600",
+				},
+			},
+		},
+	},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-cronjob-1637931600-abcde",
+				Namespace: "default",
+				Labels: map[string]string{
+					"job-name": "example-cronjob-1637931600",
+				},
+			},
+			Status: v1.PodStatus{
+				StartTime: &metav1.Time{
+					Time: time.Now().Add(-time.Hour * 2),
+				},
+			},
+		},
+	)
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := CronJobAnalyzer{}
+	analysisResults, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #770 <!-- Issue # here -->

## 📑 Description
add cronjob max time flag on analyze. if `--cronjob-max-time` flag is given, cronjob analyzer will detect cronjob that is running more than `--cronjob-max-time`.
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
please, check analyzer test code. i'm not sure putting `viper.Set(~~)`on test function is proper way to test.
Also, We need to think about where it's appropriate to put the flag validating code. For now, `time.ParseDuration(cronjobMaxTime)` is duplicated on `analyze.go` and `cronjob.go`

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->