### PR TITLE
feat: add last termination state when pod is in CrashloopBackoff

### DIFF
--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -84,6 +84,14 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						})
 					}
 				}
+
+				// This represents container that is in CrashLoopBackOff state due to conditions such as OOMKilled
+				if containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
+					failures = append(failures, common.Failure{
+						Text:      fmt.Sprintf("the last termination reason is %s container=%s pod=%s", containerStatus.LastTerminationState.Terminated.Reason, containerStatus.Name, pod.Name),
+						Sensitive: []common.Sensitive{},
+					})
+				}
 			} else {
 				// when pod is Running but its ReadinessProbe fails
 				if !containerStatus.Ready && pod.Status.Phase == "Running" {


### PR DESCRIPTION
## 📑 Description
The OOMKilled is a very short-lived container state, probably around few seconds. As soon as kubernetes sees a pod in OOMKilled state it tries to restart the pod. If pod is getting terminated and getting restarted multiple times, kubernetes marks it under CrashloopBackoff state. The event message in CrashloopBackoff state does not capture OOMKilled context. When k8sgpt PodAnalyzer sees a pod in CrashloopBackoff state it should check why pod is getting terminated/restarting (LastTerminatedState) and add it in the failure message. The following is the before and after results for containers in CrashloopBackoff state

Before
```

3 opa/opa-849dcb7499-9chrt(Deployment/opa)

- Error: back-off 5m0s restarting failed container=kube-mgmt pod=opa-849dcb7499-9chrt_opa(7f8061d3-3603-49d6-8e03-77cb4b1bbed4)

- Error: back-off 5m0s restarting failed container=opa pod=opa-849dcb7499-9chrt_opa(7f8061d3-3603-49d6-8e03-77cb4b1bbed4)

Error: The containers 'kube-mgmt' and 'opa' in the pod 'opa-849dcb7499-9chrt_opa' have failed to start and are continuously restarting.



Solution: 

1. Use 'kubectl describe pod opa-849dcb7499-9chrt_opa' to get more details about the error.

2. Check the logs of the failing containers.

3. Resolve any identified issues, such as fixing code errors or adjusting resource limits.

4. After fixing, redeploy the pod.
```

After
```
3 opa/opa-849dcb7499-9chrt(Deployment/opa)

- Error: back-off 5m0s restarting failed container=kube-mgmt pod=opa-849dcb7499-9chrt_opa(7f8061d3-3603-49d6-8e03-77cb4b1bbed4)

- Error: the last termination reason is Error container=kube-mgmt pod=opa-849dcb7499-9chrt

- Error: back-off 5m0s restarting failed container=opa pod=opa-849dcb7499-9chrt_opa(7f8061d3-3603-49d6-8e03-77cb4b1bbed4)

- Error: the last termination reason is OOMKilled container=opa pod=opa-849dcb7499-9chrt

Error: The containers 'kube-mgmt' and 'opa' in the pod 'opa-849dcb7499-9chrt' are failing to restart due to an error and 'out of memory' (OOM) issue respectively.



Solution: 

1. Check the logs for 'kube-mgmt' to identify the error.

2. Allocate more memory to the 'opa' container.

3. Restart the pod.
```


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->