### PR TITLE
feat: unify aiClientName const for all providers

### DIFF
--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/bedrockruntime"
 )
 
+const amazonbedrockAIClientName = "amazonbedrock"
+
 // AmazonBedRockClient represents the client for interacting with the Amazon Bedrock service.
 type AmazonBedRockClient struct {
 	nopCloser
@@ -147,5 +149,5 @@ func (a *AmazonBedRockClient) GetCompletion(ctx context.Context, prompt string) 
 
 // GetName returns the name of the AmazonBedRockClient.
 func (a *AmazonBedRockClient) GetName() string {
-	return "amazonbedrock"
+	return amazonbedrockAIClientName
 }

--- a/pkg/ai/amazonsagemaker.go
+++ b/pkg/ai/amazonsagemaker.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/sagemakerruntime"
 )
 
+const amazonsagemakerAIClientName = "amazonsagemaker"
+
 type SageMakerAIClient struct {
 	nopCloser
 
@@ -131,5 +133,5 @@ func (c *SageMakerAIClient) GetCompletion(_ context.Context, prompt string) (str
 }
 
 func (c *SageMakerAIClient) GetName() string {
-	return "amazonsagemaker"
+	return amazonsagemakerAIClientName
 }

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -7,6 +7,8 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+const azureAIClientName = "azureopenai"
+
 type AzureAIClient struct {
 	nopCloser
 
@@ -58,5 +60,5 @@ func (c *AzureAIClient) GetCompletion(ctx context.Context, prompt string) (strin
 }
 
 func (c *AzureAIClient) GetName() string {
-	return "azureopenai"
+	return azureAIClientName
 }

--- a/pkg/ai/cohere.go
+++ b/pkg/ai/cohere.go
@@ -20,9 +20,11 @@ import (
 	"github.com/cohere-ai/cohere-go"
 )
 
+const cohereAIClientName = "cohere"
+
 type CohereClient struct {
 	nopCloser
-	
+
 	client      *cohere.Client
 	model       string
 	temperature float32
@@ -68,5 +70,5 @@ func (c *CohereClient) GetCompletion(_ context.Context, prompt string) (string, 
 }
 
 func (c *CohereClient) GetName() string {
-	return "cohere"
+	return cohereAIClientName
 }

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -29,14 +29,14 @@ var (
 		&GoogleGenAIClient{},
 	}
 	Backends = []string{
-		"openai",
-		"localai",
-		"azureopenai",
-		"cohere",
-		"amazonbedrock",
-		"amazonsagemaker",
+		openAIClientName,
+		localAIClientName,
+		azureAIClientName,
+		cohereAIClientName,
+		amazonbedrockAIClientName,
+		amazonsagemakerAIClientName,
 		googleAIClientName,
-		"noopai",
+		noopAIClientName,
 	}
 )
 

--- a/pkg/ai/localai.go
+++ b/pkg/ai/localai.go
@@ -1,9 +1,11 @@
 package ai
 
+const localAIClientName = "localai"
+
 type LocalAIClient struct {
 	OpenAIClient
 }
 
 func (a *LocalAIClient) GetName() string {
-	return "localai"
+	return localAIClientName
 }

--- a/pkg/ai/noopai.go
+++ b/pkg/ai/noopai.go
@@ -17,6 +17,8 @@ import (
 	"context"
 )
 
+const noopAIClientName = "noopai"
+
 type NoOpAIClient struct {
 	nopCloser
 }
@@ -31,5 +33,5 @@ func (c *NoOpAIClient) GetCompletion(_ context.Context, prompt string) (string, 
 }
 
 func (c *NoOpAIClient) GetName() string {
-	return "noopai"
+	return noopAIClientName
 }

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -20,6 +20,8 @@ import (
 	"github.com/sashabaranov/go-openai"
 )
 
+const openAIClientName = "openai"
+
 type OpenAIClient struct {
 	nopCloser
 
@@ -78,5 +80,5 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 }
 
 func (c *OpenAIClient) GetName() string {
-	return "openai"
+	return openAIClientName
 }


### PR DESCRIPTION
## 📑 Description
<!-- Add a brief description of the pr -->

[GoogAI PR](https://github.com/k8sgpt-ai/k8sgpt/pull/829/files#diff-73c9c2eb51f34cd7def45a991f84e9b8e7428c4d8d541553839b81e98f91708aR26) has added a new constant to determine the AI client name. This PR unifies and adds a new constant to determine the AI client name on all providers.



## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed