### PR TITLE
ci: replace deprecated brew config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,7 @@ archives:
 brews:
   - name: k8sgpt
     homepage: https://k8sgpt.ai
-    tap:
+    repository:
       owner: k8sgpt-ai
       name: homebrew-k8sgpt
 


### PR DESCRIPTION
## 📑 Description

`tap` got replaces by `repository` and is now deprecated.

This deprecation warning can also be seen in the goreleaser logs:

>     • DEPRECATED: brews.tap should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info


https://github.com/k8sgpt-ai/k8sgpt/actions/runs/7521548656/job/20472514099

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
