### PR TITLE
test: added tests for the cmd-filters package

### DIFF
--- a/cmd/filters/add_test.go
+++ b/cmd/filters/add_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/analyzer"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddCmd(t *testing.T) {
+	require.Equal(t, "add", addCmd.Name())
+
+	// Set the configuration file in viper
+	configFileName := "config.json"
+	err := createConfigFile(map[string]interface{}{}, configFileName)
+	require.NoError(t, err)
+	defer os.Remove(configFileName)
+
+	// Set the configuration file.
+	viper.SetConfigType("json")
+	viper.SetConfigFile(configFileName)
+	err = viper.ReadInConfig()
+	require.NoError(t, err)
+
+	// Redirect the output of the color functions to buffer.
+	var buffer bytes.Buffer
+	color.Output = &buffer
+
+	// Add a filter
+	addCmd.Run(&cobra.Command{}, []string{"HorizontalPodAutoScaler"})
+	want := "Filter HorizontalPodAutoScaler added\n"
+	require.Equal(t, want, buffer.String())
+
+	// Check the length of the active filter, it should be length of core
+	// filters + 1 that was added in this test.
+	coreFilters, _, _ := analyzer.ListFilters()
+	require.Equal(t, len(coreFilters)+1, len(viper.GetStringSlice("active_filters")))
+}
+
+func createConfigFile(data map[string]interface{}, configName string) error {
+	// Create a config file
+	file, err := os.Create(configName)
+	if err != nil {
+		return err
+	}
+	// Ensure file is closed
+	defer file.Close()
+
+	// Marshal the data into a JSON byte slice
+	jsonData, err := json.MarshalIndent(data, "", "  ") // Indent for readability
+	if err != nil {
+		return fmt.Errorf("error marshalling data: %w", err)
+	}
+
+	// Write the JSON data to the file
+	_, err = file.Write(jsonData)
+	if err != nil {
+		return fmt.Errorf("error writing data to file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/filters/list.go
+++ b/cmd/filters/list.go
@@ -16,6 +16,7 @@ package filters
 import (
 	"fmt"
 	"slices"
+	"sort"
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/analyzer"
@@ -38,7 +39,12 @@ var listCmd = &cobra.Command{
 		if len(activeFilters) == 0 {
 			activeFilters = coreFilters
 		}
+
 		inactiveFilters := util.SliceDiff(availableFilters, activeFilters)
+
+		// Sort the filters list to make the output consistent for each call.
+		sort.Strings(activeFilters)
+		sort.Strings(inactiveFilters)
 		fmt.Print(color.YellowString("Active: \n"))
 		for _, filter := range activeFilters {
 			// if the filter is an integration, mark this differently

--- a/cmd/filters/remove_test.go
+++ b/cmd/filters/remove_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filters
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveCmd(t *testing.T) {
+	require.Equal(t, "remove", removeCmd.Name())
+
+	err := removeCmd.Args(&cobra.Command{}, []string{"arg1"})
+	require.NoError(t, err)
+
+	err = removeCmd.Args(&cobra.Command{}, []string{"arg1", "arg2"})
+	require.ErrorContains(t, err, "accepts 1 arg(s), received 2")
+
+	// Set the configuration file in viper
+	configFileName := "delete-config.json"
+	data := map[string]interface{}{
+		"active_filters": []string{
+			"Service",
+			"Deployment",
+			"Ingress",
+			"CronJob",
+			"MutatingWebhookConfiguration",
+			"Node",
+			"ValidatingWebhookConfiguration",
+			"PersistentVolumeClaim",
+			"StatefulSet",
+			"Pod",
+			"ReplicaSet",
+		},
+	}
+	err = createConfigFile(data, configFileName)
+	require.NoError(t, err)
+	defer os.Remove(configFileName)
+
+	viper.SetConfigType("json")
+	viper.SetConfigFile(configFileName)
+	err = viper.ReadInConfig()
+	require.NoError(t, err)
+
+	// Redirect the output of the color functions to buffer.
+	var buffer bytes.Buffer
+	color.Output = &buffer
+
+	// Remove a filter
+	removeCmd.Run(&cobra.Command{}, []string{"MutatingWebhookConfiguration"})
+	want := "Filter(s) MutatingWebhookConfiguration removed\n"
+	require.Equal(t, want, buffer.String())
+
+	// Initially the list contained 12 filters, after deleting one filter in this
+	// test, now it should be left with 11 filters only.
+	require.Equal(t, 11, len(viper.GetStringSlice("active_filters")))
+}


### PR DESCRIPTION
## 📑 Description
This commit adds new tests for the `cmd/filters` package. As a result,
the code coverage of the package has increased from 0% to almost 75% 

This also includes a minor adjustment in the list command. Now, the list
of the filters will always be in sorted order for better consistency.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed