### PR TITLE
feat: add huggingface provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Unused:
 > amazonbedrock
 > amazonsagemaker
 > google
+> huggingface
 > noopai
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.12.0 // indirect
 	github.com/gookit/color v1.5.4 // indirect
+	github.com/hupe1980/go-huggingface v0.0.15 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1672,6 +1672,8 @@ github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
+github.com/hupe1980/go-huggingface v0.0.15 h1:tTWmUGGunC/BYz4hrwS8SSVtMYVYjceG2uhL8HxeXvw=
+github.com/hupe1980/go-huggingface v0.0.15/go.mod h1:IRvsik3+b9BJyw9hCfw1arI6gDObcVto1UA8f3kt8mM=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/ai/huggingface.go
+++ b/pkg/ai/huggingface.go
@@ -1,0 +1,55 @@
+package ai
+
+import (
+	"context"
+	"github.com/hupe1980/go-huggingface"
+	"k8s.io/utils/pointer"
+)
+
+const huggingfaceAIClientName = "huggingface"
+
+type HuggingfaceClient struct {
+	nopCloser
+
+	client      *huggingface.InferenceClient
+	model       string
+	topP        float32
+	temperature float32
+	maxTokens   int
+}
+
+func (c *HuggingfaceClient) Configure(config IAIConfig) error {
+	token := config.GetPassword()
+
+	client := huggingface.NewInferenceClient(token)
+
+	c.client = client
+	c.model = config.GetModel()
+	c.topP = config.GetTopP()
+	c.temperature = config.GetTemperature()
+	c.maxTokens = config.GetMaxTokens()
+	return nil
+}
+
+func (c *HuggingfaceClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	resp, err := c.client.Conversational(ctx, &huggingface.ConversationalRequest{
+		Inputs: huggingface.ConverstationalInputs{
+			Text: prompt,
+		},
+		Model: c.model,
+		Parameters: huggingface.ConversationalParameters{
+			TopP:        pointer.Float64(float64(c.topP)),
+			Temperature: pointer.Float64(float64(c.temperature)),
+			MaxLength:   &c.maxTokens,
+		},
+		Options: huggingface.Options{
+			WaitForModel: pointer.Bool(true),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.GeneratedText, nil
+}
+
+func (c *HuggingfaceClient) GetName() string { return huggingfaceAIClientName }

--- a/pkg/ai/huggingface.go
+++ b/pkg/ai/huggingface.go
@@ -3,7 +3,7 @@ package ai
 import (
 	"context"
 	"github.com/hupe1980/go-huggingface"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 const huggingfaceAIClientName = "huggingface"
@@ -27,7 +27,11 @@ func (c *HuggingfaceClient) Configure(config IAIConfig) error {
 	c.model = config.GetModel()
 	c.topP = config.GetTopP()
 	c.temperature = config.GetTemperature()
-	c.maxTokens = config.GetMaxTokens()
+	if config.GetMaxTokens() > 500 {
+		c.maxTokens = 500
+	} else {
+		c.maxTokens = config.GetMaxTokens()
+	}
 	return nil
 }
 
@@ -38,12 +42,12 @@ func (c *HuggingfaceClient) GetCompletion(ctx context.Context, prompt string) (s
 		},
 		Model: c.model,
 		Parameters: huggingface.ConversationalParameters{
-			TopP:        pointer.Float64(float64(c.topP)),
-			Temperature: pointer.Float64(float64(c.temperature)),
+			TopP:        ptr.To[float64](float64(c.topP)),
+			Temperature: ptr.To[float64](float64(c.temperature)),
 			MaxLength:   &c.maxTokens,
 		},
 		Options: huggingface.Options{
-			WaitForModel: pointer.Bool(true),
+			WaitForModel: ptr.To[bool](true),
 		},
 	})
 	if err != nil {

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -27,6 +27,7 @@ var (
 		&AmazonBedRockClient{},
 		&SageMakerAIClient{},
 		&GoogleGenAIClient{},
+		&HuggingfaceClient{},
 	}
 	Backends = []string{
 		openAIClientName,
@@ -37,6 +38,7 @@ var (
 		amazonsagemakerAIClientName,
 		googleAIClientName,
 		noopAIClientName,
+		huggingfaceAIClientName,
 	}
 )
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #828  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
added huggingface provider.
for HF package, i use https://github.com/hupe1980/go-huggingface. i think this is more fit for k8sgpt code than [this](https://github.com/Kardbord/hfapigo). Let me know if you think differently


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Also, HF api request requires `maxtokens` less than or equal to 500. but k8sgpt`s default maxtokens is 2048 so users will get below output if they don't update or set `maxtokens`. 

How do you think setting huggingface`s default `maxtokens` to 500 if it is set k8sgpt`s default 2048?

```bash
> ./bin/k8sgpt analyze -f Service -e
   0% |                                                                                                                                                                                                                                                                                     | (0/8, 0 it/hr) [0s:0s]
Error: failed while calling AI provider huggingface: huggingfaces error: {"error":["Error in `parameters.max_length`: ensure this value is less than or equal to 500"]}
```