### PR TITLE
fix: multiple time add default backend error

### DIFF
--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -47,21 +47,11 @@ var addCmd = &cobra.Command{
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-
 		// get ai configuration
 		err := viper.UnmarshalKey("ai", &configAI)
 		if err != nil {
 			color.Red("Error: %v", err)
 			os.Exit(1)
-		}
-
-		// search for provider with same name
-		providerIndex := -1
-		for i, provider := range configAI.Providers {
-			if backend == provider.Name {
-				providerIndex = i
-				break
-			}
 		}
 
 		validBackend := func(validBackends []string, backend string) bool {
@@ -107,6 +97,15 @@ var addCmd = &cobra.Command{
 				os.Exit(1)
 			}
 			password = strings.TrimSpace(string(bytePassword))
+		}
+
+		// search for provider with same name
+		providerIndex := -1
+		for i, provider := range configAI.Providers {
+			if backend == provider.Name || defaultBackend == provider.Name {
+				providerIndex = i
+				break
+			}
 		}
 
 		// create new provider object


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #900 

## 📑 Description
In the previous command for the default authentication backend (OpenAI), we can add the authentication backend multiple times, which is not possible with other backends. Now, in this pull request I added one condition that prevent of this behaviour and give warning message `Provider with same name already exists.`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
Any suggestions you have are appreciated and helpful.