### PR TITLE
feat: support many:1 auth:provider mapping

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -28,6 +28,7 @@ import (
 var (
 	explain         bool
 	backend         string
+	configName      string
 	output          string
 	filters         []string
 	language        string
@@ -51,6 +52,7 @@ var AnalyzeCmd = &cobra.Command{
 		// Create analysis configuration first.
 		config, err := analysis.NewAnalysis(
 			backend,
+			configName,
 			language,
 			filters,
 			namespace,
@@ -126,6 +128,8 @@ func init() {
 	AnalyzeCmd.Flags().BoolVarP(&explain, "explain", "e", false, "Explain the problem to me")
 	// add flag for backend
 	AnalyzeCmd.Flags().StringVarP(&backend, "backend", "b", "", "Backend AI provider")
+	// add flag for config-name
+	AnalyzeCmd.Flags().StringVarP(&configName, "config-name", "", "", "Name of the AI provider config to use")
 	// output as json
 	AnalyzeCmd.Flags().StringVarP(&output, "output", "o", "text", "Output format (text, json)")
 	// add language options for output

--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -28,8 +28,141 @@ import (
 
 const (
 	defaultBackend = "openai"
+	defaultConfig  = "default"
 	defaultModel   = "gpt-3.5-turbo"
 )
+
+func runAddCommand(cmd *cobra.Command, args []string) {
+	// 1. Get ai configuration
+	err := viper.UnmarshalKey("ai", &configAI)
+	if err != nil {
+		color.Red("Error: %v", err)
+		os.Exit(1)
+	}
+
+	// 2. Validate input values upfront and set default values if the inputs are empty
+	// check if backend is not empty and a valid value
+	validBackend := func(validBackends []string, backend string) bool {
+		for _, b := range validBackends {
+			if b == backend {
+				return true
+			}
+		}
+		return false
+	}
+
+	if backend == "" {
+		// Set the default value of the backend provider
+		color.Yellow(fmt.Sprintf("Warning: backend input is empty, will use the default value: %s", defaultBackend))
+		backend = defaultBackend
+	} else {
+		// Check if the given provider is valid or not.
+		if !validBackend(ai.Backends, backend) {
+			color.Red("Error: Backend AI accepted values are '%v'", strings.Join(ai.Backends, ", "))
+			os.Exit(1)
+		}
+	}
+
+	// Set the value of config-name if it is not provided by the user.
+	if configName == "" {
+		color.Yellow(fmt.Sprintf("Warning: config-name input is empty, will use the default value: %s", defaultConfig))
+		configName = defaultConfig
+	}
+
+	// 3. Find existing provider index
+	// search for provider with same backend
+	providerIndex := -1
+	configIndex := -1
+	for i, provider := range configAI.Providers {
+		if backend == provider.Backend {
+			providerIndex = i
+
+			// Iterate over all the configs of this provider
+			// and check if a config with the same name already exists
+			for index, config := range provider.Configs {
+				if configName == config.Name {
+					configIndex = index
+					break
+				}
+			}
+
+			if configIndex != -1 {
+				break
+			}
+		}
+	}
+
+	// Quit if the config already exists
+	if configIndex != -1 {
+		color.Red("Provider with same config already exists.")
+		os.Exit(1)
+	}
+
+	// Handle input sanitization for config.
+	if model == "" {
+		model = defaultModel
+		color.Yellow(fmt.Sprintf("Warning: model input is empty, will use the default value: %s", defaultModel))
+	}
+	if temperature > 1.0 || temperature < 0.0 {
+		color.Red("Error: temperature ranges from 0 to 1.")
+		os.Exit(1)
+	}
+	if topP > 1.0 || topP < 0.0 {
+		color.Red("Error: topP ranges from 0 to 1.")
+		os.Exit(1)
+	}
+
+	if ai.NeedPassword(backend) && password == "" {
+		fmt.Printf("Enter %s Key: ", backend)
+		bytePassword, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			color.Red("Error reading %s Key from stdin: %s", backend,
+				err.Error())
+			os.Exit(1)
+		}
+		password = strings.TrimSpace(string(bytePassword))
+	}
+
+	// Create a new provider config
+	config := ai.AIProviderConfig{
+		Name:           configName,
+		Model:          model,
+		Password:       password,
+		BaseURL:        baseURL,
+		EndpointName:   endpointName,
+		Engine:         engine,
+		Temperature:    temperature,
+		ProviderRegion: providerRegion,
+		ProviderId:     providerId,
+		TopP:           topP,
+		MaxTokens:      maxTokens,
+	}
+
+	// Create a new provider if the providerIndex is -1
+	if providerIndex == -1 {
+		// Instantiate a new provider if it is not already present.
+		newProvider := ai.AIProvider{
+			Backend: backend,
+			Configs: []ai.AIProviderConfig{
+				config,
+			},
+			DefaultConfig: 0,
+		}
+
+		// provider with this backend name does not exist, add new provider to list
+		configAI.Providers = append(configAI.Providers, newProvider)
+	} else {
+		// Append this config in the configs of the ai provider
+		configAI.Providers[providerIndex].Configs = append(configAI.Providers[providerIndex].Configs, config)
+	}
+
+	viper.Set("ai", configAI)
+	if err := viper.WriteConfig(); err != nil {
+		color.Red("Error writing config file: %s", err.Error())
+		os.Exit(1)
+	}
+	color.Green("%s added to the AI backend provider list", backend)
+}
 
 var addCmd = &cobra.Command{
 	Use:   "add",
@@ -49,103 +182,14 @@ var addCmd = &cobra.Command{
 			_ = cmd.MarkFlagRequired("providerRegion")
 		}
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-
-		// get ai configuration
-		err := viper.UnmarshalKey("ai", &configAI)
-		if err != nil {
-			color.Red("Error: %v", err)
-			os.Exit(1)
-		}
-
-		// search for provider with same name
-		providerIndex := -1
-		for i, provider := range configAI.Providers {
-			if backend == provider.Name {
-				providerIndex = i
-				break
-			}
-		}
-
-		validBackend := func(validBackends []string, backend string) bool {
-			for _, b := range validBackends {
-				if b == backend {
-					return true
-				}
-			}
-			return false
-		}
-
-		// check if backend is not empty and a valid value
-		if backend == "" {
-			color.Yellow(fmt.Sprintf("Warning: backend input is empty, will use the default value: %s", defaultBackend))
-			backend = defaultBackend
-		} else {
-			if !validBackend(ai.Backends, backend) {
-				color.Red("Error: Backend AI accepted values are '%v'", strings.Join(ai.Backends, ", "))
-				os.Exit(1)
-			}
-		}
-
-		// check if model is not empty
-		if model == "" {
-			model = defaultModel
-			color.Yellow(fmt.Sprintf("Warning: model input is empty, will use the default value: %s", defaultModel))
-		}
-		if temperature > 1.0 || temperature < 0.0 {
-			color.Red("Error: temperature ranges from 0 to 1.")
-			os.Exit(1)
-		}
-		if topP > 1.0 || topP < 0.0 {
-			color.Red("Error: topP ranges from 0 to 1.")
-			os.Exit(1)
-		}
-
-		if ai.NeedPassword(backend) && password == "" {
-			fmt.Printf("Enter %s Key: ", backend)
-			bytePassword, err := term.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				color.Red("Error reading %s Key from stdin: %s", backend,
-					err.Error())
-				os.Exit(1)
-			}
-			password = strings.TrimSpace(string(bytePassword))
-		}
-
-		// create new provider object
-		newProvider := ai.AIProvider{
-			Name:           backend,
-			Model:          model,
-			Password:       password,
-			BaseURL:        baseURL,
-			EndpointName:   endpointName,
-			Engine:         engine,
-			Temperature:    temperature,
-			ProviderRegion: providerRegion,
-			ProviderId:     providerId,
-			TopP:           topP,
-			MaxTokens:      maxTokens,
-		}
-
-		if providerIndex == -1 {
-			// provider with same name does not exist, add new provider to list
-			configAI.Providers = append(configAI.Providers, newProvider)
-			viper.Set("ai", configAI)
-			if err := viper.WriteConfig(); err != nil {
-				color.Red("Error writing config file: %s", err.Error())
-				os.Exit(1)
-			}
-			color.Green("%s added to the AI backend provider list", backend)
-		} else {
-			// provider with same name exists, update provider info
-			color.Yellow("Provider with same name already exists.")
-		}
-	},
+	Run: runAddCommand,
 }
 
 func init() {
 	// add flag for backend
 	addCmd.Flags().StringVarP(&backend, "backend", "b", defaultBackend, "Backend AI provider")
+	// add flag for config-name
+	addCmd.Flags().StringVarP(&configName, "config-name", "", defaultConfig, "Backend AI provider")
 	// add flag for model
 	addCmd.Flags().StringVarP(&model, "model", "m", defaultModel, "Backend AI model")
 	// add flag for password

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -20,6 +20,7 @@ import (
 
 var (
 	backend        string
+	configName     string
 	password       string
 	baseURL        string
 	endpointName   string

--- a/cmd/auth/default.go
+++ b/cmd/auth/default.go
@@ -26,54 +26,94 @@ var (
 	providerName string
 )
 
-var defaultCmd = &cobra.Command{
-	Use:   "default",
-	Short: "Set your default AI backend provider",
-	Long:  "The command to set your new default AI backend provider (default is openai)",
-	Run: func(cmd *cobra.Command, args []string) {
-		err := viper.UnmarshalKey("ai", &configAI)
-		if err != nil {
-			color.Red("Error: %v", err)
-			os.Exit(1)
-		}
-		if providerName == "" {
-			if configAI.DefaultProvider != "" {
-				color.Yellow("Your default provider is %s", configAI.DefaultProvider)
-			} else {
-				color.Yellow("Your default provider is openai")
-			}
-			os.Exit(0)
-		}
-		// lowercase the provider name
-		providerName = strings.ToLower(providerName)
+func runDefaultCommand(cmd *cobra.Command, args []string) {
+	// 1. Get the ai configurations
+	err := viper.UnmarshalKey("ai", &configAI)
+	if err != nil {
+		color.Red("Error: %v", err)
+		os.Exit(1)
+	}
 
-		// Check if the provider is in the provider list
-		providerExists := false
-		for _, provider := range configAI.Providers {
-			if provider.Name == providerName {
-				providerExists = true
+	// 2. Validate the input values and set defaults if necessary
+	if providerName == "" {
+		if configAI.DefaultProvider != "" {
+			color.Yellow("Your default provider is \"%s\"", configAI.DefaultProvider)
+		} else {
+			color.Yellow("Your default provider is openai")
+		}
+		os.Exit(0)
+	}
+
+	// lowercase the provider name
+	providerName = strings.ToLower(providerName)
+
+	// Check if the provider is in the provider list
+	providerIndex := -1
+	configIndex := -1
+	for i, provider := range configAI.Providers {
+		if providerName == provider.Backend {
+			providerIndex = i
+
+			// Iterate over all the configs of this provider
+			// and check if a config with the same name exists
+			if configName != "" {
+				for index, config := range provider.Configs {
+					if configName == config.Name {
+						configIndex = index
+						break
+					}
+				}
+			}
+
+			if configIndex != -1 {
+				break
 			}
 		}
-		if !providerExists {
-			color.Red("Error: Provider %s does not exist", providerName)
-			os.Exit(1)
-		}
+	}
+
+	if providerIndex == -1 {
+		color.Red("Error: Provider \"%s\" does not exist", providerName)
+		os.Exit(1)
+	}
+
+	if configIndex == -1 && configName != "" {
+		color.Red("Error: The backend provider \"%s\" does not have a configuration with the name \"%s\"", backend, configName)
+		os.Exit(1)
+	}
+
+	if configName != "" {
+		// Set the default config
+		configAI.Providers[providerIndex].DefaultConfig = configIndex
+	} else {
 		// Set the default provider
 		configAI.DefaultProvider = providerName
+	}
 
-		viper.Set("ai", configAI)
-		// Viper write config
-		err = viper.WriteConfig()
-		if err != nil {
-			color.Red("Error: %v", err)
-			os.Exit(1)
-		}
-		// Print acknowledgement
+	viper.Set("ai", configAI)
+	// Viper write config
+	err = viper.WriteConfig()
+	if err != nil {
+		color.Red("Error: %v", err)
+		os.Exit(1)
+	}
+
+	// Print acknowledgement
+	if configName != "" {
+		color.Green("Default config for %s set to %s", providerName, configName)
+	} else {
 		color.Green("Default provider set to %s", providerName)
-	},
+	}
+}
+
+var defaultCmd = &cobra.Command{
+	Use:   "default",
+	Short: "Set your default AI backend provider and provider config",
+	Long:  "The command to set your new default AI backend provider (default is openai)",
+	Run:   runDefaultCommand,
 }
 
 func init() {
 	// provider name flag
 	defaultCmd.Flags().StringVarP(&providerName, "provider", "p", "", "The name of the provider to set as default")
+	defaultCmd.Flags().StringVarP(&configName, "config-name", "", "", "The name of the config to set as default for a provider")
 }

--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -25,74 +25,75 @@ import (
 
 var details bool
 
+func runListCommand(cmd *cobra.Command, args []string) {
+	// Get the ai configurations
+	err := viper.UnmarshalKey("ai", &configAI)
+	if err != nil {
+		color.Red("Error: %v", err)
+		os.Exit(1)
+	}
+
+	// Print the default if it is set
+	fmt.Print(color.YellowString("Default: \n"))
+	if configAI.DefaultProvider != "" {
+		fmt.Printf("> %s\n", color.BlueString(configAI.DefaultProvider))
+	} else {
+		fmt.Printf("> %s\n", color.BlueString("openai"))
+	}
+
+	// Get list of all AI Backends and only print them if they are not in the provider list
+	fmt.Print(color.YellowString("Active: \n"))
+	for _, provider := range configAI.Providers {
+		fmt.Printf("> %s\n", color.GreenString(provider.Backend))
+		fmt.Println("  > " + color.HiCyanString("Configs"))
+
+		for index, config := range provider.Configs {
+			if index == provider.DefaultConfig {
+				fmt.Printf("    %d. %s "+color.HiYellowString("(Default Config)\n"), index+1, config.Name)
+			} else {
+				fmt.Printf("    %d. %s\n", index+1, config.Name)
+			}
+			if details {
+				printDetails(provider, index)
+			}
+		}
+	}
+
+	fmt.Print(color.YellowString("Unused: \n"))
+	for _, aiBackend := range ai.Backends {
+		providerExists := false
+		for _, provider := range configAI.Providers {
+			if provider.Backend == aiBackend {
+				providerExists = true
+			}
+		}
+		if !providerExists {
+			fmt.Printf("> %s\n", color.RedString(aiBackend))
+		}
+	}
+}
+
+func printDetails(provider ai.AIProvider, index int) {
+	if provider.Configs[index].Model != "" {
+		fmt.Printf("       - Model: %s\n", provider.Configs[index].Model)
+	}
+
+	if provider.Configs[index].Engine != "" {
+		fmt.Printf("       - Engine: %s\n", provider.Configs[index].Engine)
+	}
+
+	if provider.Configs[index].BaseURL != "" {
+		fmt.Printf("       - BaseURL: %s\n", provider.Configs[index].BaseURL)
+	}
+}
+
 var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List configured providers",
 	Long:  "The list command displays a list of configured providers",
-	Run: func(cmd *cobra.Command, args []string) {
-
-		// get ai configuration
-		err := viper.UnmarshalKey("ai", &configAI)
-		if err != nil {
-			color.Red("Error: %v", err)
-			os.Exit(1)
-		}
-
-		// Print the default if it is set
-		fmt.Print(color.YellowString("Default: \n"))
-		if configAI.DefaultProvider != "" {
-			fmt.Printf("> %s\n", color.BlueString(configAI.DefaultProvider))
-		} else {
-			fmt.Printf("> %s\n", color.BlueString("openai"))
-		}
-
-		// Get list of all AI Backends and only print them if they are not in the provider list
-		fmt.Print(color.YellowString("Active: \n"))
-		for _, aiBackend := range ai.Backends {
-			providerExists := false
-			for _, provider := range configAI.Providers {
-				if provider.Name == aiBackend {
-					providerExists = true
-				}
-			}
-			if providerExists {
-				fmt.Printf("> %s\n", color.GreenString(aiBackend))
-				if details {
-					for _, provider := range configAI.Providers {
-						if provider.Name == aiBackend {
-							printDetails(provider)
-						}
-					}
-				}
-			}
-		}
-		fmt.Print(color.YellowString("Unused: \n"))
-		for _, aiBackend := range ai.Backends {
-			providerExists := false
-			for _, provider := range configAI.Providers {
-				if provider.Name == aiBackend {
-					providerExists = true
-				}
-			}
-			if !providerExists {
-				fmt.Printf("> %s\n", color.RedString(aiBackend))
-			}
-		}
-	},
+	Run:   runListCommand,
 }
 
 func init() {
 	listCmd.Flags().BoolVar(&details, "details", false, "Print active provider configuration details")
-}
-
-func printDetails(provider ai.AIProvider) {
-	if provider.Model != "" {
-		fmt.Printf("   - Model: %s\n", provider.Model)
-	}
-	if provider.Engine != "" {
-		fmt.Printf("   - Engine: %s\n", provider.Engine)
-	}
-	if provider.BaseURL != "" {
-		fmt.Printf("   - BaseURL: %s\n", provider.BaseURL)
-	}
 }

--- a/cmd/auth/remove.go
+++ b/cmd/auth/remove.go
@@ -22,6 +22,98 @@ import (
 	"github.com/spf13/viper"
 )
 
+func runRemoveCommand(cmd *cobra.Command, args []string) {
+	// Get the ai configurations
+	err := viper.UnmarshalKey("ai", &configAI)
+	if err != nil {
+		color.Red("Error: %v", err)
+		os.Exit(1)
+	}
+
+	// Check if the backend flag is set.
+	if backend == "" {
+		color.Red("Error: backends must be set.")
+		_ = cmd.Help()
+		return
+	}
+
+	inputBackends := strings.Split(backend, ",")
+
+	if configName == "" {
+		color.Yellow("Warning: No config is specified therefore the default config will be removed")
+	}
+
+	// Now, iterate over each backend
+	for _, backendName := range inputBackends {
+		foundBackend := false
+		for i, provider := range configAI.Providers {
+			// Check if the input backend is present in the list of providers stored
+			// in the config file.
+			if backendName == provider.Backend {
+				foundBackend = true
+
+				// Now, start iterating over the configs stored in the backend
+				deletedConfigIndex := -1
+
+				if configName == "" {
+					// Delete the current default config if no config name has been specified.
+					deletedConfigIndex = provider.DefaultConfig
+					configName = provider.Configs[provider.DefaultConfig].Name
+				} else {
+					for index, config := range provider.Configs {
+						if configName == config.Name {
+							deletedConfigIndex = index
+							break
+						}
+					}
+				}
+
+				if deletedConfigIndex != -1 {
+					// Remove the config if it is found.
+					configAI.Providers[i].Configs = append(configAI.Providers[i].Configs[:deletedConfigIndex], configAI.Providers[i].Configs[deletedConfigIndex+1:]...)
+					color.Green("Config: \"%s\" deleted for the AI backend provider: \"%s\"", configName, backendName)
+				} else {
+					color.Red("Error: Backend provider \"%s\" didn't have any config with name \"%s\". Aborting!", backendName, configName)
+					os.Exit(1)
+				}
+
+				// Now, check if there are any configs left for this backend provider.
+				if len(configAI.Providers[i].Configs) == 0 {
+					// Delete this backend provider.
+					configAI.Providers = append(configAI.Providers[:i], configAI.Providers[i+1:]...)
+
+					// Check if this was also the default provider.
+					if configAI.DefaultProvider == backendName {
+						// Update the default backend to the first item in the backend list
+						if len(configAI.Providers) != 0 {
+							configAI.DefaultProvider = configAI.Providers[0].Backend
+						} else {
+							// If there are no providers left. Fallback to default.
+							configAI.DefaultProvider = defaultBackend
+						}
+					}
+				} else if deletedConfigIndex == configAI.Providers[i].DefaultConfig {
+					// Update the default config for this backend provider to config at 0th index.
+					configAI.Providers[i].DefaultConfig = 0
+					color.Yellow("After deleting the config \"%s\", the default config for backend provider \"%s\" has changed to \"%s\"", configName, backendName, configAI.Providers[i].Configs[0].Name)
+				}
+
+				break
+			}
+		}
+		if !foundBackend {
+			color.Red("Error: \"%s\" does not exist in configuration file. Please use k8sgpt auth new.", backendName)
+			os.Exit(1)
+		}
+	}
+
+	viper.Set("ai", configAI)
+	if err := viper.WriteConfig(); err != nil {
+		color.Red("Error writing config file: %s", err.Error())
+		os.Exit(1)
+	}
+}
+
 var removeCmd = &cobra.Command{
 	Use:   "remove",
 	Short: "Remove provider(s)",
@@ -29,49 +121,11 @@ var removeCmd = &cobra.Command{
 	PreRun: func(cmd *cobra.Command, args []string) {
 		_ = cmd.MarkFlagRequired("backends")
 	},
-	Run: func(cmd *cobra.Command, args []string) {
-		if backend == "" {
-			color.Red("Error: backends must be set.")
-			_ = cmd.Help()
-			return
-		}
-		inputBackends := strings.Split(backend, ",")
-
-		err := viper.UnmarshalKey("ai", &configAI)
-		if err != nil {
-			color.Red("Error: %v", err)
-			os.Exit(1)
-		}
-
-		for _, b := range inputBackends {
-			foundBackend := false
-			for i, provider := range configAI.Providers {
-				if b == provider.Name {
-					foundBackend = true
-					configAI.Providers = append(configAI.Providers[:i], configAI.Providers[i+1:]...)
-					if configAI.DefaultProvider == b {
-						configAI.DefaultProvider = "openai"
-					}
-					color.Green("%s deleted from the AI backend provider list", b)
-					break
-				}
-			}
-			if !foundBackend {
-				color.Red("Error: %s does not exist in configuration file. Please use k8sgpt auth new.", b)
-				os.Exit(1)
-			}
-		}
-
-		viper.Set("ai", configAI)
-		if err := viper.WriteConfig(); err != nil {
-			color.Red("Error writing config file: %s", err.Error())
-			os.Exit(1)
-		}
-
-	},
+	Run: runRemoveCommand,
 }
 
 func init() {
 	// add flag for backends
 	removeCmd.Flags().StringVarP(&backend, "backends", "b", "", "Backend AI providers to remove (separated by a comma)")
+	removeCmd.Flags().StringVarP(&configName, "config-name", "", "", "Name of the config to remove")
 }

--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -92,10 +92,10 @@ func GetRegionOrDefault(region string) string {
 }
 
 // Configure configures the AmazonBedRockClient with the provided configuration.
-func (a *AmazonBedRockClient) Configure(config IAIConfig) error {
+func (a *AmazonBedRockClient) Configure(config IAIConfig, index int) error {
 
 	// Create a new AWS session
-	providerRegion := GetRegionOrDefault(config.GetProviderRegion())
+	providerRegion := GetRegionOrDefault(config.GetProviderRegion(index))
 
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(providerRegion),
@@ -107,8 +107,8 @@ func (a *AmazonBedRockClient) Configure(config IAIConfig) error {
 
 	// Create a new BedrockRuntime client
 	a.client = bedrockruntime.New(sess)
-	a.model = GetModelOrDefault(config.GetModel())
-	a.temperature = config.GetTemperature()
+	a.model = GetModelOrDefault(config.GetModel(index))
+	a.temperature = config.GetTemperature(index)
 
 	return nil
 }

--- a/pkg/ai/amazonsagemaker.go
+++ b/pkg/ai/amazonsagemaker.go
@@ -59,21 +59,21 @@ type Parameters struct {
 	Temperature  float64 `json:"temperature"`
 }
 
-func (c *SageMakerAIClient) Configure(config IAIConfig) error {
+func (c *SageMakerAIClient) Configure(config IAIConfig, index int) error {
 
 	// Create a new AWS session
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		Config:            aws.Config{Region: aws.String(config.GetProviderRegion())},
+		Config:            aws.Config{Region: aws.String(config.GetProviderRegion(index))},
 		SharedConfigState: session.SharedConfigEnable,
 	}))
 
 	// Create a new SageMaker runtime client
 	c.client = sagemakerruntime.New(sess)
-	c.model = config.GetModel()
-	c.endpoint = config.GetEndpointName()
-	c.temperature = config.GetTemperature()
-	c.maxTokens = config.GetMaxTokens()
-	c.topP = config.GetTopP()
+	c.model = config.GetModel(index)
+	c.endpoint = config.GetEndpointName(index)
+	c.temperature = config.GetTemperature(index)
+	c.maxTokens = config.GetMaxTokens(index)
+	c.topP = config.GetTopP(index)
 	return nil
 }
 

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -19,11 +19,11 @@ type AzureAIClient struct {
 	temperature float32
 }
 
-func (c *AzureAIClient) Configure(config IAIConfig) error {
-	token := config.GetPassword()
-	baseURL := config.GetBaseURL()
-	engine := config.GetEngine()
-	proxyEndpoint := config.GetProxyEndpoint()
+func (c *AzureAIClient) Configure(config IAIConfig, index int) error {
+	token := config.GetPassword(index)
+	baseURL := config.GetBaseURL(index)
+	engine := config.GetEngine(index)
+	proxyEndpoint := config.GetProxyEndpoint(index)
 	defaultConfig := openai.DefaultAzureConfig(token, baseURL)
 
 	defaultConfig.AzureModelMapperFunc = func(model string) string {
@@ -53,8 +53,8 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 		return errors.New("error creating Azure OpenAI client")
 	}
 	c.client = client
-	c.model = config.GetModel()
-	c.temperature = config.GetTemperature()
+	c.model = config.GetModel(index)
+	c.temperature = config.GetTemperature(index)
 	return nil
 }
 

--- a/pkg/ai/cohere.go
+++ b/pkg/ai/cohere.go
@@ -33,14 +33,14 @@ type CohereClient struct {
 	maxTokens   int
 }
 
-func (c *CohereClient) Configure(config IAIConfig) error {
-	token := config.GetPassword()
+func (c *CohereClient) Configure(config IAIConfig, index int) error {
+	token := config.GetPassword(index)
 
 	opts := []option.RequestOption{
 		cohere.WithToken(token),
 	}
 
-	baseURL := config.GetBaseURL()
+	baseURL := config.GetBaseURL(index)
 	if baseURL != "" {
 		opts = append(opts, cohere.WithBaseURL(baseURL))
 	}
@@ -51,9 +51,9 @@ func (c *CohereClient) Configure(config IAIConfig) error {
 	}
 
 	c.client = client
-	c.model = config.GetModel()
-	c.temperature = config.GetTemperature()
-	c.maxTokens = config.GetMaxTokens()
+	c.model = config.GetModel(index)
+	c.temperature = config.GetTemperature(index)
+	c.maxTokens = config.GetMaxTokens(index)
 
 	return nil
 }

--- a/pkg/ai/googlegenai.go
+++ b/pkg/ai/googlegenai.go
@@ -34,11 +34,11 @@ type GoogleGenAIClient struct {
 	maxTokens   int
 }
 
-func (c *GoogleGenAIClient) Configure(config IAIConfig) error {
+func (c *GoogleGenAIClient) Configure(config IAIConfig, index int) error {
 	ctx := context.Background()
 
 	// Access your API key as an environment variable (see "Set up your API key" above)
-	token := config.GetPassword()
+	token := config.GetPassword(index)
 	authOption := option.WithAPIKey(token)
 	if token[0] == '{' {
 		authOption = option.WithCredentialsJSON([]byte(token))
@@ -50,10 +50,10 @@ func (c *GoogleGenAIClient) Configure(config IAIConfig) error {
 	}
 
 	c.client = client
-	c.model = config.GetModel()
-	c.temperature = config.GetTemperature()
-	c.topP = config.GetTopP()
-	c.maxTokens = config.GetMaxTokens()
+	c.model = config.GetModel(index)
+	c.temperature = config.GetTemperature(index)
+	c.topP = config.GetTopP(index)
+	c.maxTokens = config.GetMaxTokens(index)
 	return nil
 }
 

--- a/pkg/ai/googlevertexai.go
+++ b/pkg/ai/googlevertexai.go
@@ -95,12 +95,12 @@ func GetVertexAIRegionOrDefault(region string) string {
 	return VERTEXAI_DEFAULT_REGION
 }
 
-func (g *GoogleVertexAIClient) Configure(config IAIConfig) error {
+func (g *GoogleVertexAIClient) Configure(config IAIConfig, index int) error {
 	ctx := context.Background()
 
 	// Currently you can access VertexAI either by being authenticated via OAuth or Bearer token so we need to consider both
-	projectId := config.GetProviderId()
-	region := GetVertexAIRegionOrDefault(config.GetProviderRegion())
+	projectId := config.GetProviderId(index)
+	region := GetVertexAIRegionOrDefault(config.GetProviderRegion(index))
 
 	client, err := genai.NewClient(ctx, projectId, region)
 	if err != nil {
@@ -108,10 +108,10 @@ func (g *GoogleVertexAIClient) Configure(config IAIConfig) error {
 	}
 
 	g.client = client
-	g.model = GetVertexAIModelOrDefault(config.GetModel())
-	g.temperature = config.GetTemperature()
-	g.topP = config.GetTopP()
-	g.maxTokens = config.GetMaxTokens()
+	g.model = GetVertexAIModelOrDefault(config.GetModel(index))
+	g.temperature = config.GetTemperature(index)
+	g.topP = config.GetTopP(index)
+	g.maxTokens = config.GetMaxTokens(index)
 
 	return nil
 }

--- a/pkg/ai/huggingface.go
+++ b/pkg/ai/huggingface.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"context"
+
 	"github.com/hupe1980/go-huggingface"
 	"k8s.io/utils/ptr"
 )
@@ -18,19 +19,19 @@ type HuggingfaceClient struct {
 	maxTokens   int
 }
 
-func (c *HuggingfaceClient) Configure(config IAIConfig) error {
-	token := config.GetPassword()
+func (c *HuggingfaceClient) Configure(config IAIConfig, index int) error {
+	token := config.GetPassword(index)
 
 	client := huggingface.NewInferenceClient(token)
 
 	c.client = client
-	c.model = config.GetModel()
-	c.topP = config.GetTopP()
-	c.temperature = config.GetTemperature()
-	if config.GetMaxTokens() > 500 {
+	c.model = config.GetModel(index)
+	c.topP = config.GetTopP(index)
+	c.temperature = config.GetTemperature(index)
+	if config.GetMaxTokens(index) > 500 {
 		c.maxTokens = 500
 	} else {
-		c.maxTokens = config.GetMaxTokens()
+		c.maxTokens = config.GetMaxTokens(index)
 	}
 	return nil
 }

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -48,7 +48,7 @@ var (
 type IAI interface {
 	// Configure sets up client for given configuration. This is expected to be
 	// executed once per client life-time (e.g. analysis CLI command invocation).
-	Configure(config IAIConfig) error
+	Configure(config IAIConfig, index int) error
 	// GetCompletion generates text based on prompt.
 	GetCompletion(ctx context.Context, prompt string) (string, error)
 	// GetName returns name of the backend/client.
@@ -63,17 +63,17 @@ type nopCloser struct{}
 func (nopCloser) Close() {}
 
 type IAIConfig interface {
-	GetPassword() string
-	GetModel() string
-	GetBaseURL() string
-	GetProxyEndpoint() string
-	GetEndpointName() string
-	GetEngine() string
-	GetTemperature() float32
-	GetProviderRegion() string
-	GetTopP() float32
-	GetMaxTokens() int
-	GetProviderId() string
+	GetPassword(index int) string
+	GetModel(index int) string
+	GetBaseURL(index int) string
+	GetProxyEndpoint(index int) string
+	GetEndpointName(index int) string
+	GetEngine(index int) string
+	GetTemperature(index int) float32
+	GetProviderRegion(index int) string
+	GetTopP(index int) float32
+	GetMaxTokens(index int) int
+	GetProviderId(index int) string
 }
 
 func NewClient(provider string) IAI {
@@ -92,6 +92,12 @@ type AIConfiguration struct {
 }
 
 type AIProvider struct {
+	Backend       string
+	Configs       []AIProviderConfig
+	DefaultConfig int
+}
+
+type AIProviderConfig struct {
 	Name           string  `mapstructure:"name"`
 	Model          string  `mapstructure:"model"`
 	Password       string  `mapstructure:"password" yaml:"password,omitempty"`
@@ -107,47 +113,47 @@ type AIProvider struct {
 	MaxTokens      int     `mapstructure:"maxtokens" yaml:"maxtokens,omitempty"`
 }
 
-func (p *AIProvider) GetBaseURL() string {
-	return p.BaseURL
+func (p *AIProvider) GetBaseURL(index int) string {
+	return p.Configs[index].BaseURL
 }
 
-func (p *AIProvider) GetProxyEndpoint() string {
-	return p.ProxyEndpoint
+func (p *AIProvider) GetProxyEndpoint(index int) string {
+	return p.Configs[index].ProxyEndpoint
 }
 
-func (p *AIProvider) GetEndpointName() string {
-	return p.EndpointName
+func (p *AIProvider) GetEndpointName(index int) string {
+	return p.Configs[index].EndpointName
 }
 
-func (p *AIProvider) GetTopP() float32 {
-	return p.TopP
+func (p *AIProvider) GetTopP(index int) float32 {
+	return p.Configs[index].TopP
 }
 
-func (p *AIProvider) GetMaxTokens() int {
-	return p.MaxTokens
+func (p *AIProvider) GetMaxTokens(index int) int {
+	return p.Configs[index].MaxTokens
 }
 
-func (p *AIProvider) GetPassword() string {
-	return p.Password
+func (p *AIProvider) GetPassword(index int) string {
+	return p.Configs[index].Password
 }
 
-func (p *AIProvider) GetModel() string {
-	return p.Model
+func (p *AIProvider) GetModel(index int) string {
+	return p.Configs[index].Model
 }
 
-func (p *AIProvider) GetEngine() string {
-	return p.Engine
+func (p *AIProvider) GetEngine(index int) string {
+	return p.Configs[index].Engine
 }
-func (p *AIProvider) GetTemperature() float32 {
-	return p.Temperature
-}
-
-func (p *AIProvider) GetProviderRegion() string {
-	return p.ProviderRegion
+func (p *AIProvider) GetTemperature(index int) float32 {
+	return p.Configs[index].Temperature
 }
 
-func (p *AIProvider) GetProviderId() string {
-	return p.ProviderId
+func (p *AIProvider) GetProviderRegion(index int) string {
+	return p.Configs[index].ProviderRegion
+}
+
+func (p *AIProvider) GetProviderId(index int) string {
+	return p.Configs[index].ProviderId
 }
 
 var passwordlessProviders = []string{"localai", "amazonsagemaker", "amazonbedrock", "googlevertexai"}

--- a/pkg/ai/noopai.go
+++ b/pkg/ai/noopai.go
@@ -23,7 +23,7 @@ type NoOpAIClient struct {
 	nopCloser
 }
 
-func (c *NoOpAIClient) Configure(_ IAIConfig) error {
+func (c *NoOpAIClient) Configure(_ IAIConfig, _ int) error {
 	return nil
 }
 

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -40,12 +40,12 @@ const (
 	frequencyPenalty = 0.0
 )
 
-func (c *OpenAIClient) Configure(config IAIConfig) error {
-	token := config.GetPassword()
+func (c *OpenAIClient) Configure(config IAIConfig, index int) error {
+	token := config.GetPassword(index)
 	defaultConfig := openai.DefaultConfig(token)
-	proxyEndpoint := config.GetProxyEndpoint()
+	proxyEndpoint := config.GetProxyEndpoint(index)
 
-	baseURL := config.GetBaseURL()
+	baseURL := config.GetBaseURL(index)
 	if baseURL != "" {
 		defaultConfig.BaseURL = baseURL
 	}
@@ -69,9 +69,9 @@ func (c *OpenAIClient) Configure(config IAIConfig) error {
 		return errors.New("error creating OpenAI client")
 	}
 	c.client = client
-	c.model = config.GetModel()
-	c.temperature = config.GetTemperature()
-	c.topP = config.GetTopP()
+	c.model = config.GetModel(index)
+	c.temperature = config.GetTemperature(index)
+	c.topP = config.GetTopP(index)
 	return nil
 }
 


### PR DESCRIPTION
## 📑 Description
Added the ability to add multiple configurations for the same backend
provider.

One to one auth:provider mapping had many bugs and users were requesting
many to one auth:provider mapping functionality for more flexibility
with backend provider configurations.

This commit also includes the addition of an optional `--config-name`
flag to allow users to specify the config-name while configuring backend
AI providers.

Changes exclusive to individual subcommands are:
1. default
  - `--config-name` flag has been added to allow users to update the 
    default configuration for a backend AI provider.
  - Setting the `--config-name` flag will only update the default
    configuration for the specified backend, it will not update the 
    `configAI.DefaultProvider`.
  - To update the `configAI.DefaultProvider`, user must leave the 
    `--config-name` flag unset.

2. list
  - The list subcommand will now respect the value of `userInput` set 
    when the user is asked to show password or not.
  - The command's output has been modified to display the backend
    providers list along with their configuration names.
  - Default configs for each backend AI provider are marked with the 
    `(Default Config)` string in bright yellow color.

3. remove
  - Users can specify either single or multiple backends when
    removing the configurations.
  - If the `--config-name` flag is not set, the "default" configuration
    for the specified backend(s) will be removed(if it is present).
  - Setting the `--config-name` flag will specify the configuration name
    to delete for each of the specified backends.

4. Update
  - Now the user can only specify a single backend provider at a time.
    This has been done because updating multiple backend configs with
    same values of parameters doesn't make any sense.
  - Removal of the `Args` function because update subcommand can have
    multiple args to set different parameters for a backend config.
  - Users can also update the configuration name for an already existing
    config.

Addresses:
- https://github.com/k8sgpt-ai/k8sgpt/issues/936
- https://github.com/k8sgpt-ai/k8sgpt/issues/911
- https://github.com/k8sgpt-ai/k8sgpt/issues/905
- https://github.com/k8sgpt-ai/k8sgpt/issues/900
- https://github.com/k8sgpt-ai/k8sgpt/issues/843

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed