### PR TITLE
fix: shorthand for the http flag in serve command

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -160,5 +160,5 @@ func init() {
 	ServeCmd.Flags().StringVarP(&port, "port", "p", "8080", "Port to run the server on")
 	ServeCmd.Flags().StringVarP(&metricsPort, "metrics-port", "", "8081", "Port to run the metrics-server on")
 	ServeCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
-	ServeCmd.Flags().BoolVarP(&enableHttp, "http", "h", false, "Enable REST/http using gppc-gateway")
+	ServeCmd.Flags().BoolVarP(&enableHttp, "http", "", false, "Enable REST/http using gppc-gateway")
 }


### PR DESCRIPTION
Closes #968 

## 📑 Description
Removed the shorthand for the `http` flag in the serve command because it was contradicting with the shorthand of the `help` command which is automatically added on execution if the `help` flag is not already defined.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed