### PR TITLE
feat: add proxysettings for azureopenai and openai

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -73,6 +73,7 @@ var ServeCmd = &cobra.Command{
 			model := os.Getenv("K8SGPT_MODEL")
 			baseURL := os.Getenv("K8SGPT_BASEURL")
 			engine := os.Getenv("K8SGPT_ENGINE")
+			proxyEndpoint := os.Getenv("K8SGPT_PROXY_ENDPOINT")
 			// If the envs are set, allocate in place to the aiProvider
 			// else exit with error
 			envIsSet := backend != "" || password != "" || model != ""
@@ -83,6 +84,7 @@ var ServeCmd = &cobra.Command{
 					Model:       model,
 					BaseURL:     baseURL,
 					Engine:      engine,
+					ProxyEndpoint: proxyEndpoint,
 					Temperature: temperature(),
 				}
 

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -64,6 +64,7 @@ type IAIConfig interface {
 	GetPassword() string
 	GetModel() string
 	GetBaseURL() string
+	GetProxyEndpoint() string
 	GetEndpointName() string
 	GetEngine() string
 	GetTemperature() float32
@@ -92,6 +93,8 @@ type AIProvider struct {
 	Model          string  `mapstructure:"model"`
 	Password       string  `mapstructure:"password" yaml:"password,omitempty"`
 	BaseURL        string  `mapstructure:"baseurl" yaml:"baseurl,omitempty"`
+	ProxyEndpoint  string  `mapstructure:"proxyEndpoint" yaml:"proxyEndpoint,omitempty"`
+	ProxyPort      string  `mapstructure:"proxyPort" yaml:"proxyPort,omitempty"`
 	EndpointName   string  `mapstructure:"endpointname" yaml:"endpointname,omitempty"`
 	Engine         string  `mapstructure:"engine" yaml:"engine,omitempty"`
 	Temperature    float32 `mapstructure:"temperature" yaml:"temperature,omitempty"`
@@ -102,6 +105,10 @@ type AIProvider struct {
 
 func (p *AIProvider) GetBaseURL() string {
 	return p.BaseURL
+}
+
+func (p *AIProvider) GetProxyEndpoint() string {
+	return p.ProxyEndpoint
 }
 
 func (p *AIProvider) GetEndpointName() string {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/k8sgpt-ai/k8sgpt-operator/issues/307

## 📑 Description
<!-- Add a brief description of the pr -->
This PR adds proxyEndpoint for openai and azureopenai config for the request to be reached through an HTTP like proxy. Tested this manually on azureopenai and openai. This can be used by using an Environment Variable `K8SGPT_PROXY_ENDPOINT` while using the tool.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->