### PR TITLE
test: added tests for the PDB analyzer

### DIFF
--- a/pkg/analyzer/pdb.go
+++ b/pkg/analyzer/pdb.go
@@ -50,6 +50,11 @@ func (PdbAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 
 	for _, pdb := range list.Items {
 		var failures []common.Failure
+
+		// Before accessing the Conditions, check if they exist or not.
+		if len(pdb.Status.Conditions) == 0 {
+			continue
+		}
 		if pdb.Status.Conditions[0].Type == "DisruptionAllowed" && pdb.Status.Conditions[0].Status == "False" {
 			var doc string
 			if pdb.Spec.MaxUnavailable != nil {

--- a/pkg/analyzer/pdb_test.go
+++ b/pkg/analyzer/pdb_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/stretchr/testify/require"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type Expectations struct {
+	name     string
+	failures []string
+}
+
+func TestPodDisruptionBudgetAnalyzer(t *testing.T) {
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "PDB1",
+						Namespace: "test",
+					},
+					// Status conditions are nil.
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: nil,
+					},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "PDB2",
+						Namespace: "test",
+					},
+					// Status conditions are empty.
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []metav1.Condition{},
+					},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "PDB3",
+						Namespace: "test",
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "DisruptionAllowed",
+								Status: "False",
+								Reason: "test reason",
+							},
+						},
+					},
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						MaxUnavailable: &intstr.IntOrString{
+							Type:   0,
+							IntVal: 17,
+							StrVal: "17",
+						},
+						MinAvailable: &intstr.IntOrString{
+							Type:   0,
+							IntVal: 7,
+							StrVal: "7",
+						},
+						// MatchLabels specified.
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"label1": "test1",
+								"label2": "test2",
+							},
+						},
+					},
+				},
+				&policyv1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "PDB4",
+						Namespace: "test",
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   "DisruptionAllowed",
+								Status: "False",
+								Reason: "test reason",
+							},
+						},
+					},
+					// Match Labels Empty.
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						Selector: &metav1.LabelSelector{},
+					},
+				},
+			),
+		},
+		Context:   context.Background(),
+		Namespace: "test",
+	}
+	expectations := []Expectations{
+		{
+			name: "test/PDB3",
+			failures: []string{
+				"test reason, expected pdb pod label label1=test1",
+				"test reason, expected pdb pod label label2=test2",
+			},
+		},
+	}
+
+	pdbAnalyzer := PdbAnalyzer{}
+	results, err := pdbAnalyzer.Analyze(config)
+	require.NoError(t, err)
+
+	for i, expectation := range expectations {
+		require.Equal(t, expectation.name, results[i].Name)
+		for j, failure := range expectation.failures {
+			require.Equal(t, failure, results[i].Error[j].Text)
+		}
+	}
+}


### PR DESCRIPTION
## 📑 Description
This commit introduces comprehensive tests for the `PodDisruptionBudget` analyzer defined in the `pkg/analyzer` package.

Adding these tests increases the code coverage of the `pdb.go` file to >96%.

Additionally, a potential crash in case of empty or nil PDB status conditions has been addressed.

Partially addresses: https://github.com/k8sgpt-ai/k8sgpt/issues/889

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed