### PR TITLE
chore: update renovate config and bundle deps in groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,29 +18,24 @@
   "platformAutomerge": true,
   "packageRules": [
     {
-      "matchPackageNames": ["^github.com/Azure/azure-sdk-for-go/"],
+      "matchPackageNames": ["azure-sdk-for-go"],
       "enabled": true,
-      "group": "azure-group"
+      "groupName": "azure-group"
     },
     {
-      "matchPackageNames": ["^github.com/prometheus/"],
+      "matchPackageNames": ["prometheus"],
       "enabled": true,
-      "group": "prometheus-group"
+      "groupName": "prometheus-group"
     },
     {
-      "matchPackageNames": ["^k8s.io/", "^sigs.k8s.io/"],
+      "matchPackageNames": ["k8s.io", "sigs.k8s.io"],
       "enabled": true,
       "groupName": "kubernetes-group"
     },
     {
-      "matchPackageNames": ["^github.com/golang/","^golang.org"],
+      "matchPackageNames": ["golang"],
       "enabled": true,
-      "group": "golang-group"
-    },
-    {
-      "matchPackageNames": ["^github.com/"],
-      "enabled": true,
-      "group": "github arbitrary dependencies"
+      "groupName": "golang-group"
     },
     {
       "description": "Exclude retracted cohere-go versions: https://github.com/renovatebot/renovate/issues/13012",


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1008 <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Fixes the renovate config file and make the groups more visible,
I am adding 4  dependency groups "golang, k8s, prometheus and azure"; golang's and k8s' dep updates are  quite often. This is the first iteration (with a valid renovate.conf file) to bundle our deps to avoid PR fatigue
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
I ran it against renovate-config-validator and was happy