### PR TITLE
chore: update license file path to avoid conflicting installations (#…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,7 @@ nfpms:
     section: utils
     contents:
       - src: ./LICENSE
-        dst: /usr/share/doc/nfpm/copyright
+        dst: /usr/share/doc/k8sgpt/copyright
         file_info:
           mode: 0644
 


### PR DESCRIPTION
…878)

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #878

## 📑 Description
I noticed that a number of tools using goreleaser (including glasskube and k9s) store the copyright file on the same path, making installing all of these tools at the same time impossible because of conflicts. This should be the fix. 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
https://github.com/glasskube/glasskube/issues/531