### PR TITLE
fix: remove shorthand flag for topp option in add command

### DIFF
--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -161,7 +161,7 @@ func init() {
 	// add flag for endpointName
 	addCmd.Flags().StringVarP(&endpointName, "endpointname", "n", "", "Endpoint Name, e.g. `endpoint-xxxxxxxxxxxx` (only for amazonbedrock, amazonsagemaker backends)")
 	// add flag for topP
-	addCmd.Flags().Float32VarP(&topP, "topp", "c", 0.5, "Probability Cutoff: Set a threshold (0.0-1.0) to limit word choices. Higher values add randomness, lower values increase predictability.")
+	addCmd.Flags().Float32VarP(&topP, "topp", "", 0.5, "Probability Cutoff: Set a threshold (0.0-1.0) to limit word choices. Higher values add randomness, lower values increase predictability.")
 	// add flag for topK
 	addCmd.Flags().Int32VarP(&topK, "topk", "c", 50, "Sampling Cutoff: Set a threshold (1-100) to restrict the sampling process to the top K most probable words at each step. Higher values lead to greater variability, lower values increases predictability.")
 	// max tokens


### PR DESCRIPTION
see some build failure in https://github.com/Homebrew/homebrew-core/pull/171893

```
==> /home/linuxbrew/.linuxbrew/Cellar/k8sgpt/0.3.31/bin/k8sgpt analyze --explain --filter=Service
  panic: unable to redefine 'c' shorthand in "add" flagset: it's already used for "topp" flag
  
  goroutine 1 [running]:
  github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0001c6e00, 0xc00055bae0)
  	github.com/spf13/pflag@v1.0.5/flag.go:874 +0x3f5
  github.com/spf13/pflag.(*FlagSet).VarPF(0xc0001c6e00, {0x4bf0978, 0x6868708}, {0x433bbd3, 0x4}, {0x4bb9e70, 0x1}, {0x444b73e, 0xca})
  	github.com/spf13/pflag@v1.0.5/flag.go:831 +0x105
  github.com/spf13/pflag.(*FlagSet).VarP(...)
  	github.com/spf13/pflag@v1.0.5/flag.go:837
  github.com/spf13/pflag.(*FlagSet).Int32VarP(0x4427598?, 0x5e?, {0x433bbd3?, 0x10?}, {0x4bb9e70?, 0x3d7[51](https://github.com/Homebrew/homebrew-core/actions/runs/9115237344/job/25061178026?pr=171893#step:4:52)01?}, 0x4bb1f48?, {0x444b73e?, 0x0?})
  	github.com/spf13/pflag@v1.0.5/int32.go:50 +0x45
  github.com/k8sgpt-ai/k8sgpt/cmd/auth.init.0()
  	github.com/k8sgpt-ai/k8sgpt/cmd/auth/add.go:166 +0x229
  
  Error: k8sgpt: failed
  Error: k8sgpt: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected: 1
    Actual: 2
```

thus removing shorthand flag for topp option