### PR TITLE
fix: call grpc schema.v1.ServerService/Analyze Print Error Stack "[co…

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -18,11 +18,13 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
+	"github.com/go-logr/logr"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
 	k8sgptserver "github.com/k8sgpt-ai/k8sgpt/pkg/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -137,6 +139,9 @@ var ServeCmd = &cobra.Command{
 		}
 
 		logger, err := zap.NewProduction()
+
+		log.SetLogger(logr.New(log.NullLogSink{}))
+
 		if err != nil {
 			color.Red("failed to create logger: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
call grpc schema.v1.ServerService/Analyze Print Error Stack :
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed."

detail error:
Starting: /Users/gus/go/bin/dlv dap --listen=127.0.0.1:49392 --log-dest=3 from /Users/gus/data/code/git/github/k8sgpt
DAP server listening at: 127.0.0.1:49392
Type 'dlv help' for list of commands.
{"level":"info","ts":1717057272.390344,"caller":"server/server.go:126","msg":"binding metrics to 8081"}
{"level":"info","ts":1717057272.39065,"caller":"server/server.go:92","msg":"binding api to 8080"}
{"level":"info","ts":1717057300.040952,"caller":"server/log.go:50","msg":"request completed","duration_ms":22602,"method":"/schema.v1.ServerService/Analyze","request":"max_concurrency:10  output:\"json\"","remote_addr":"127.0.0.1:50506"}
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 306 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/Users/gus/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/log.go:60 +0xa0
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithName(0x14000916e40, {0x107e5264e, 0x14})
	>  	/Users/gus/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/log/deleg.go:147 +0x34
	>  github.com/go-logr/logr.Logger.WithName({{0x108f674d8, 0x14000916e40}, 0x0}, {0x107e5264e, 0x14})
	>  	/Users/gus/go/pkg/mod/github.com/go-logr/logr@v1.4.1/logr.go:345 +0x5c
	>  sigs.k8s.io/controller-runtime/pkg/client.newClient(0x14000d84900, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/Users/gus/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:122 +0xf8
	>  sigs.k8s.io/controller-runtime/pkg/client.New(0x14000774fc0, {0x0, 0x0, {0x0, 0x0}, 0x0, {0x0, 0x0}, 0x0})
	>  	/Users/gus/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/client/client.go:103 +0x78
	>  github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes.NewClient({0x0, 0x0}, {0x0, 0x0})
	>  	/Users/gus/data/code/git/github/k8sgpt/pkg/kubernetes/kubernetes.go:62 +0x300
	>  github.com/k8sgpt-ai/k8sgpt/pkg/analysis.NewAnalysis({0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0, 0x0}, {0x0, 0x0}, 0x0, ...)
	>  	/Users/gus/data/code/git/github/k8sgpt/pkg/analysis/analysis.go:86 +0xac
	>  github.com/k8sgpt-ai/k8sgpt/pkg/server.(*handler).Analyze(0x0, {0x108f60db0, 0x140011810e0}, 0x140011dcd80)
	>  	/Users/gus/data/code/git/github/k8sgpt/pkg/server/analyze.go:23 +0x198
	>  buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc._ServerService_Analyze_Handler.func1({0x108f60db0, 0x140011810e0}, {0x108da7260, 0x140011dcd80})
	>  	/Users/gus/go/pkg/mod/buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go@v1.3.0-20240406062209-1cc152efbf5c.3/schema/v1/schemav1grpc/server-service_grpc.pb.go:134 +0xb0
	>  github.com/k8sgpt-ai/k8sgpt/pkg/server.logInterceptor.func1({0x108f60db0, 0x140011810e0}, {0x108da7260, 0x140011dcd80}, 0x14000aeffa0, 0x14000d8c930)
	>  	/Users/gus/data/code/git/github/k8sgpt/pkg/server/log.go:19 +0x88
	>  buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc._ServerService_Analyze_Handler({0x108b7cb00, 0x0}, {0x108f60db0, 0x140011810e0}, 0x14000b86700, 0x14000676aa0)
	>  	/Users/gus/go/pkg/mod/buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go@v1.3.0-20240406062209-1cc152efbf5c.3/schema/v1/schemav1grpc/server-service_grpc.pb.go:136 +0x1d8
	>  google.golang.org/grpc.(*Server).processUnaryRPC(0x14000747800, {0x108f60db0, 0x14001181050}, {0x108f6d640, 0x140001b8b60}, 0x14000eefd40, 0x14000ad3b90, 0x10a8c5cc0, 0x0)
	>  	/Users/gus/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1386 +0x1360
	>  google.golang.org/grpc.(*Server).handleStream(0x14000747800, {0x108f6d640, 0x140001b8b60}, 0x14000eefd40)
	>  	/Users/gus/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1797 +0xd00
	>  google.golang.org/grpc.(*Server).serveStreams.func2.1()
	>  	/Users/gus/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1027 +0xf4
	>  created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 99
	>  	/Users/gus/go/pkg/mod/google.golang.org/grpc@v1.62.1/server.go:1038 +0x1c8
{"level":"info","ts":1717057325.634251,"caller":"server/log.go:50","msg":"request completed","duration_ms":22450,"method":"/schema.v1.ServerService/Analyze","request":"max_concurrency:10  output:\"json\"","remote_addr":"127.0.0.1:50506"}

