### PR TITLE
fix: call grpc schema.v1.ServerService/Analyze Print Error Stack

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -18,11 +18,13 @@ import (
 	"strconv"
 
 	"github.com/fatih/color"
+	"github.com/go-logr/logr"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
 	k8sgptserver "github.com/k8sgpt-ai/k8sgpt/pkg/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -137,6 +139,9 @@ var ServeCmd = &cobra.Command{
 		}
 
 		logger, err := zap.NewProduction()
+
+		log.SetLogger(logr.New(log.NullLogSink{}))
+
 		if err != nil {
 			color.Red("failed to create logger: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
 "[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed."

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->