### PR TITLE
feat: add watsonx ai provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Unused:
 > huggingface
 > noopai
 > googlevertexai
+> watsonxai
 ```
 
 For detailed documentation on how to configure and use each provider see [here](https://docs.k8sgpt.ai/reference/providers/backend/).

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.8.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/IBM/watsonx-go v1.0.0 // indirect
 	github.com/Microsoft/hcsshim v0.12.4 // indirect
 	github.com/alecthomas/units v0.0.0-20231202071711-9a357b53e9c9 // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20230627203149-c72ef8859ca9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1245,6 +1245,8 @@ github.com/Code-Hex/go-generics-cache v1.3.1 h1:i8rLwyhoyhaerr7JpjtYjJZUcCbWOdiY
 github.com/Code-Hex/go-generics-cache v1.3.1/go.mod h1:qxcC9kRVrct9rHeiYpFWSoW1vxyillCVzX13KZG8dl4=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/IBM/watsonx-go v1.0.0 h1:xG7xA2W9N0RsiztR26dwBI8/VxIX4wTBhdYmEis2Yl8=
+github.com/IBM/watsonx-go v1.0.0/go.mod h1:8lzvpe/158JkrzvcoIcIj6OdNty5iC9co5nQHfkhRtM=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -30,6 +30,7 @@ var (
 		&HuggingfaceClient{},
 		&GoogleVertexAIClient{},
 		&OCIGenAIClient{},
+		&WatsonxAIClient{},
 	}
 	Backends = []string{
 		openAIClientName,
@@ -43,6 +44,7 @@ var (
 		huggingfaceAIClientName,
 		googleVertexAIClientName,
 		ociClientName,
+		watsonxAIClientName,
 	}
 )
 
@@ -170,7 +172,7 @@ func (p *AIProvider) GetOrganizationId() string {
 	return p.OrganizationId
 }
 
-var passwordlessProviders = []string{"localai", "amazonsagemaker", "amazonbedrock", "googlevertexai", "oci"}
+var passwordlessProviders = []string{"localai", "amazonsagemaker", "amazonbedrock", "googlevertexai", "oci", "watsonxai"}
 
 func NeedPassword(backend string) bool {
 	for _, b := range passwordlessProviders {

--- a/pkg/ai/watsonxai.go
+++ b/pkg/ai/watsonxai.go
@@ -1,0 +1,84 @@
+package ai
+
+import (
+	"os"
+	"fmt"
+	"context"
+	"errors"
+
+	wx "github.com/IBM/watsonx-go/pkg/models"
+)
+
+const watsonxAIClientName = "watsonxai"
+
+type WatsonxAIClient struct {
+	nopCloser
+
+	client         *wx.Client
+	model          string
+	temperature    float32
+	topP           float32
+	topK           int32
+	maxNewTokens   int
+}
+
+const (
+	modelMetallama = "ibm/granite-13b-chat-v2"
+)
+
+func (c *WatsonxAIClient) Configure(config IAIConfig) error {
+	if(config.GetModel() == "") {
+		c.model = config.GetModel()
+	} else {
+		c.model = modelMetallama
+	}
+	c.temperature = config.GetTemperature()
+	c.topP = config.GetTopP()
+	c.topK = config.GetTopK()
+	c.maxNewTokens = config.GetMaxTokens()
+
+	// WatsonxAPIKeyEnvVarName    = "WATSONX_API_KEY"
+	// WatsonxProjectIDEnvVarName = "WATSONX_PROJECT_ID"
+	apiKey, projectID := os.Getenv(wx.WatsonxAPIKeyEnvVarName), os.Getenv(wx.WatsonxProjectIDEnvVarName)
+
+	if apiKey == "" {
+		return errors.New("No watsonx API key provided")
+	}
+	if projectID == "" {
+		return errors.New("No watsonx project ID provided")
+	}
+
+	client, err := wx.NewClient(
+		wx.WithWatsonxAPIKey(apiKey),
+		wx.WithWatsonxProjectID(projectID),
+	)
+	if err != nil {
+		return fmt.Errorf("Failed to create client for testing. Error: %v", err)
+	}
+	c.client = client
+
+	return nil
+}
+
+func (c *WatsonxAIClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	result, err := c.client.GenerateText(
+		c.model,
+		prompt,
+		wx.WithTemperature((float64)(c.temperature)),
+		wx.WithTopP((float64)(c.topP)),
+		wx.WithTopK((uint)(c.topK)),
+		wx.WithMaxNewTokens((uint)(c.maxNewTokens)),
+	)
+	if err != nil {
+		return "", fmt.Errorf("Expected no error, but got an error: %v", err)
+	}
+	if result.Text == "" {
+		return "", errors.New("Expected a result, but got an empty string")
+	}
+
+	return result.Text, nil
+}
+
+func (c *WatsonxAIClient) GetName() string {
+	return watsonxAIClientName
+}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Add IBM watsonx ai as AI provider for k8sGPT.
Document: https://github.com/k8sgpt-ai/docs/pull/107

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

The API key and project ID are hidden for security
```shell
$ k8sgpt auth add -b watsonxai -m ibm/granite-13b-chat-v2
watsonxai added to the AI backend provider list
$ export WATSONX_API_KEY=**************************
$ export WATSONX_PROJECT_ID=**************************
$ k8sgpt analyze -b watsonxai --explain

 100% || (3/3, 26 it/min)
AI Provider: watsonxai

0: Service openshift-machine-api/machine-api-controllers()
- Error: Service has no endpoints, expected label k8s-app=controller

Error: Service has no endpoints, expected label k8s-app=controller
Solution: Check the pod's annotations and ensure the label `k8s-app=controller` is present. If it's not, apply the label using the command `kubectl label pods <pod-name> k8s-app=controller`.
If the pod already has the label, check the service's selector and ensure it matches the pod's label. If it doesn't, update the service's selector using the command `kubectl apply -f <service-file>.yaml` and reapply the service.
If you're still experiencing issues, try checking the pod's status and the service's status using the command `kubectl get pods` and `kubectl get services`, respectively. This will help you identify any potential configuration issues.


1: Service openshift-machine-api/machine-api-operator-machine-webhook()
- Error: Service has no endpoints, expected label api=clusterapi
- Error: Service has no endpoints, expected label k8s-app=controller

Error: Service has no endpoints, expected label {api=clusterapi, k8s-app=controller}
Solution: Add the label "api=clusterapi" and "k8s-app=controller" to the service in the Kubernetes configuration file. This will ensure that the service has the required endpoints and labels.


2: Service openshift-machine-api/machine-api-operator-webhook()
- Error: Service has no endpoints, expected label api=clusterapi
- Error: Service has no endpoints, expected label k8s-app=controller

Error: Service has no endpoints, expected label {api=clusterapi, k8s-app=controller}
Solution: Add the label "api=clusterapi" and "k8s-app=controller" to the service in the Kubernetes configuration file. This will ensure that the service has the required endpoints and labels.