### PR TITLE
fix: set logger for controller-runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/IBM/watsonx-go v1.0.1
 	github.com/aws/aws-sdk-go v1.53.21
 	github.com/cohere-ai/cohere-go/v2 v2.7.3
+	github.com/go-logr/zapr v1.3.0
 	github.com/google/generative-ai-go v0.11.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0
 	github.com/hupe1980/go-huggingface v0.0.15

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -25,11 +25,13 @@ import (
 
 	gw "buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc-ecosystem/gateway/v2/schema/v1/server-service/schemav1gateway"
 	rpc "buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc"
+	"github.com/go-logr/zapr"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -80,6 +82,8 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Ha
 }
 
 func (s *Config) Serve() error {
+	ctrl.SetLogger(zapr.NewLogger(s.Logger))
+
 	var lis net.Listener
 	var err error
 	address := fmt.Sprintf(":%s", s.Port)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1208  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Set logger for controller-runtime.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Testing done:
- `make docker-build` -> ok
- After applying the newly built Docker image in k8sgpt-operator, this log `[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.` is no longer present.