### PR TITLE
feat: added the ability to set a default AI provider for serve

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -153,6 +153,17 @@ var ServeCmd = &cobra.Command{
 				os.Exit(1)
 			}
 		}
+
+		// Backend string will have high priority than a default provider
+		// Hence, use the default provider only if the backend is not specified by the user.
+		if configAI.DefaultProvider != "" && backend == "" {
+			backend = configAI.DefaultProvider
+		}
+		// Using default provider openai
+		if backend == "" {
+			backend = "openai"
+		}
+
 		if aiProvider == nil {
 			for _, provider := range configAI.Providers {
 				if backend == provider.Name {
@@ -214,6 +225,6 @@ func init() {
 	// add flag for backend
 	ServeCmd.Flags().StringVarP(&port, "port", "p", "8080", "Port to run the server on")
 	ServeCmd.Flags().StringVarP(&metricsPort, "metrics-port", "", "8081", "Port to run the metrics-server on")
-	ServeCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
+	ServeCmd.Flags().StringVarP(&backend, "backend", "b", "", "Backend AI provider")
 	ServeCmd.Flags().BoolVarP(&enableHttp, "http", "", false, "Enable REST/http using gppc-gateway")
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

The `k8sgpt serve` default backend is hardcoded as `openai`.
The PR is to add the ability to set a default AI provider for `serve` by configure the same as the command `analysis`

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->