### PR TITLE
fix: helm chart security context rendering if empty

### DIFF
--- a/charts/k8sgpt/templates/deployment.yaml
+++ b/charts/k8sgpt/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- if .Values.deployment.securityContext }}
       securityContext:
         {{- toYaml .Values.deployment.securityContext | nindent 8 }}
-      {{ end -}}
+      {{- end }}
       serviceAccountName: {{ template "k8sgpt.fullname" . }}
       containers:
       - name: k8sgpt-container


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

When `.Values.deployment.securityContext` is empty (`{}`), the helm installation fails with
```
Error: YAML parse error on k8sgpt/templates/deployment.yaml: error converting YAML to JSON: yaml: lin
e 24: mapping values are not allowed in this context                                                 
                                                                                                     
Use --debug flag to render out invalid YAML 
```

This fixes the rendering.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->