### PR TITLE
fix: add providerId to serve mode

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -14,9 +14,10 @@ limitations under the License.
 package serve
 
 import (
-	k8sgptserver "github.com/k8sgpt-ai/k8sgpt/pkg/server"
 	"os"
 	"strconv"
+
+	k8sgptserver "github.com/k8sgpt-ai/k8sgpt/pkg/server"
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
@@ -108,6 +109,7 @@ var ServeCmd = &cobra.Command{
 			baseURL := os.Getenv("K8SGPT_BASEURL")
 			engine := os.Getenv("K8SGPT_ENGINE")
 			proxyEndpoint := os.Getenv("K8SGPT_PROXY_ENDPOINT")
+			providerId := os.Getenv("K8SGPT_PROVIDER_ID")
 			// If the envs are set, allocate in place to the aiProvider
 			// else exit with error
 			envIsSet := backend != "" || password != "" || model != ""
@@ -119,6 +121,7 @@ var ServeCmd = &cobra.Command{
 					BaseURL:       baseURL,
 					Engine:        engine,
 					ProxyEndpoint: proxyEndpoint,
+					ProviderId:    providerId,
 					Temperature:   temperature(),
 					TopP:          topP(),
 					TopK:          topK(),


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description

In the ibmwatsonxai AI backend, it requires `providerId` and it is indispensable. Refer to [PR](https://github.com/k8sgpt-ai/k8sgpt/pull/1190). Therefore, we need to add providerId parameter in the `serve` mode so that we can enable ibmwatsonxai in k8sgpt-operator to pass the providerId parameters.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->