### PR TITLE
fix: update OpenAI API key generation URL to reflect new platform link

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -45,7 +45,7 @@ var GenerateCmd = &cobra.Command{
 			backendType = backend
 		}
 		fmt.Println("")
-		openbrowser("https://beta.openai.com/account/api-keys")
+		openbrowser("https://platform.openai.com/api-keys")
 	},
 }
 
@@ -81,10 +81,10 @@ func openbrowser(url string) {
 func printInstructions(isGui bool, backendType string) {
 	fmt.Println("")
 	if isGui {
-		color.Green("Opening: https://beta.openai.com/account/api-keys to generate a key for %s", backendType)
+		color.Green("Opening: https://platform.openai.com/api-keys to generate a key for %s", backendType)
 		fmt.Println("")
 	} else {
-		color.Green("Please open: https://beta.openai.com/account/api-keys to generate a key for %s", backendType)
+		color.Green("Please open: https://platform.openai.com/api-keys to generate a key for %s", backendType)
 		fmt.Println("")
 	}
 	color.Green("Please copy the generated key and run `k8sgpt auth add` to add it to your config file")


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Updated the outdated OpenAI API key generation URL from https://beta.openai.com/account/api-keys to the current https://platform.openai.com/account/api-keys. This fixes the issue where users were directed to an incorrect page when running the k8sgpt generate command.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [✅] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
This change ensures that users are directed to the correct OpenAI platform URL for API key generation, aligning the behavior of the k8sgpt generate command with the current OpenAI platform structure. No breaking changes or new dependencies were introduced.