### PR TITLE
feat: enable to source customHeaders from the config file

### DIFF
--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -119,7 +119,7 @@ type AIProvider struct {
 	TopK           int32         `mapstructure:"topk" yaml:"topk,omitempty"`
 	MaxTokens      int           `mapstructure:"maxtokens" yaml:"maxtokens,omitempty"`
 	OrganizationId string        `mapstructure:"organizationid" yaml:"organizationid,omitempty"`
-	CustomHeaders  []http.Header `mapstructure:"customHeaders"`
+	CustomHeaders  []http.Header `mapstructure:"customHeaders" yaml:"customHeaders,omitempty"`
 }
 
 func (p *AIProvider) GetBaseURL() string {

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -155,7 +155,7 @@ func NewAnalysis(
 
 	aiClient := ai.NewClient(aiProvider.Name)
 	customHeaders := util.NewHeaders(httpHeaders)
-	aiProvider.CustomHeaders = customHeaders
+	aiProvider.CustomHeaders = append(aiProvider.CustomHeaders, customHeaders...)
 	if err := aiClient.Configure(&aiProvider); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR introduces the ability to read custom headers directly from the configuration file. The existing behavior is preserved: custom headers passed via the CLI are appended to those specified in the configuration file, which can be left empty.

Upon reviewing the source code, I noticed that `customHeaders` are sometimes "blanked" to prevent exposing sensitive data. https://github.com/k8sgpt-ai/k8sgpt/blob/c3f448693d7648a1a98dbf1f714464d1b0724f89/cmd/dump/dump.go#L60 This likely explains why the initial implementation did not support reading `customHeaders` from the configuration file. However, this limitation prevents the operator from leveraging `customHeaders` in configurations. 

This PR addresses the issue by enabling `customHeaders` to be defined in the configuration file, making it more flexible and useful for the operator. 

Please confirm if my understanding aligns with the intended behavior, and let me know if you would prefer I open an issue for tracking this change. Also, I noticed the documentation has a section regarding `customHeaders`, I'll be happy to update that one as well if this change is acceptable.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Here is an example of writing the headers in the configuration file:
```yaml
ai:
    providers:
        - name: openai
          ...
          customHeaders:
            - Header-1: value-header-1
            - Header-2: value-header-2
    defaultprovider: openai
kubeconfig: ""
kubecontext: ""
```