### PR TITLE
feat: add a naive support of bedrock inference profile

### DIFF
--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime/bedrockruntimeiface"
 	"os"
+	"strings"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai/bedrock_support"
 
@@ -255,7 +256,7 @@ func GetRegionOrDefault(region string) string {
 // Get model from string
 func (a *AmazonBedRockClient) getModelFromString(model string) (*bedrock_support.BedrockModel, error) {
 	for _, m := range models {
-		if model == m.Name {
+		if strings.Contains(model, m.Name) || strings.Contains(model, m.Config.ModelName) {
 			return &m, nil
 		}
 	}

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -1,0 +1,18 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBedrockModelConfig(t *testing.T) {
+	client := AmazonBedRockClient{}
+
+	foundModel, err := client.getModelFromString("arn:aws:bedrock:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
+	assert.Nil(t, err, "Error should be nil")
+	assert.Equal(t, foundModel.Config.MaxTokens, 100)
+	assert.Equal(t, foundModel.Config.Temperature, float32(0.5))
+	assert.Equal(t, foundModel.Config.TopP, float32(0.9))
+	assert.Equal(t, foundModel.Config.ModelName, "anthropic.claude-3-5-sonnet-20240620-v1:0")
+}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # https://github.com/k8sgpt-ai/k8sgpt/issues/1442

## 📑 Description
Taking advantage of the naming conversion of the AWS Bedrock inference profile, match inference profile arn to the predefined enum of model ID

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [] My code requires changes to the documentation
- [] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->