### PR TITLE
feat: add a naive support of bedrock inference profile

### DIFF
--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/aws/aws-sdk-go/service/bedrockruntime/bedrockruntimeiface"
 	"os"
+	"strings"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai/bedrock_support"
 
@@ -255,7 +256,7 @@ func GetRegionOrDefault(region string) string {
 // Get model from string
 func (a *AmazonBedRockClient) getModelFromString(model string) (*bedrock_support.BedrockModel, error) {
 	for _, m := range models {
-		if model == m.Name {
+		if strings.Contains(model, m.Name) || strings.Contains(model, m.Config.ModelName) {
 			return &m, nil
 		}
 	}

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -3,11 +3,38 @@ package ai
 import (
 	"testing"
 
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai/bedrock_support"
 	"github.com/stretchr/testify/assert"
 )
 
+// Test models for unit testing
+var testModels = []bedrock_support.BedrockModel{
+	{
+		Name:       "anthropic.claude-3-5-sonnet-20240620-v1:0",
+		Completion: &bedrock_support.CohereMessagesCompletion{},
+		Response:   &bedrock_support.CohereMessagesResponse{},
+		Config: bedrock_support.BedrockModelConfig{
+			MaxTokens:   100,
+			Temperature: 0.5,
+			TopP:        0.9,
+			ModelName:   "anthropic.claude-3-5-sonnet-20240620-v1:0",
+		},
+	},
+	{
+		Name:       "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		Completion: &bedrock_support.CohereCompletion{},
+		Response:   &bedrock_support.CohereResponse{},
+		Config: bedrock_support.BedrockModelConfig{
+			MaxTokens:   100,
+			Temperature: 0.5,
+			TopP:        0.9,
+			ModelName:   "anthropic.claude-3-5-sonnet-20241022-v2:0",
+		},
+	},
+}
+
 func TestBedrockModelConfig(t *testing.T) {
-	client := AmazonBedRockClient{}
+	client := &AmazonBedRockClient{models: testModels}
 
 	foundModel, err := client.getModelFromString("arn:aws:bedrock:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
 	assert.Nil(t, err, "Error should be nil")
@@ -15,4 +42,90 @@ func TestBedrockModelConfig(t *testing.T) {
 	assert.Equal(t, foundModel.Config.Temperature, float32(0.5))
 	assert.Equal(t, foundModel.Config.TopP, float32(0.9))
 	assert.Equal(t, foundModel.Config.ModelName, "anthropic.claude-3-5-sonnet-20240620-v1:0")
+}
+
+func TestGetModelFromString(t *testing.T) {
+	client := &AmazonBedRockClient{models: testModels}
+
+	tests := []struct {
+		name      string
+		model     string
+		wantModel string
+		wantErr   bool
+	}{
+		{
+			name:      "exact model name match",
+			model:     "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			wantModel: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			wantErr:   false,
+		},
+		{
+			name:      "partial model name match",
+			model:     "claude-3-5-sonnet",
+			wantModel: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			wantErr:   false,
+		},
+		{
+			name:      "model name with different version",
+			model:     "anthropic.claude-3-5-sonnet-20241022-v2:0",
+			wantModel: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+			wantErr:   false,
+		},
+		{
+			name:      "non-existent model",
+			model:     "non-existent-model",
+			wantModel: "",
+			wantErr:   true,
+		},
+		{
+			name:      "empty model name",
+			model:     "",
+			wantModel: "",
+			wantErr:   true,
+		},
+		{
+			name:      "model name with extra spaces",
+			model:     "  anthropic.claude-3-5-sonnet-20240620-v1:0  ",
+			wantModel: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			wantErr:   false,
+		},
+		{
+			name:      "case insensitive match",
+			model:     "ANTHROPIC.CLAUDE-3-5-SONNET-20240620-V1:0",
+			wantModel: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModel, err := client.getModelFromString(tt.model)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getModelFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && gotModel.Name != tt.wantModel {
+				t.Errorf("getModelFromString() = %v, want %v", gotModel.Name, tt.wantModel)
+			}
+		})
+	}
+}
+
+// TestDefaultModels tests that the client works with default models
+func TestDefaultModels(t *testing.T) {
+	client := &AmazonBedRockClient{}
+
+	// Configure should initialize default models
+	err := client.Configure(&AIProvider{
+		Model: "anthropic.claude-v2",
+	})
+
+	assert.NoError(t, err, "Configure should not return an error")
+	assert.NotNil(t, client.models, "Models should be initialized")
+	assert.NotEmpty(t, client.models, "Models should not be empty")
+
+	// Test finding a default model
+	model, err := client.getModelFromString("anthropic.claude-v2")
+	assert.NoError(t, err, "Should find the model")
+	assert.Equal(t, "anthropic.claude-v2", model.Name, "Should find the correct model")
 }

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -1,0 +1,18 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBedrockModelConfig(t *testing.T) {
+	client := AmazonBedRockClient{}
+
+	foundModel, err := client.getModelFromString("arn:aws:bedrock:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
+	assert.Nil(t, err, "Error should be nil")
+	assert.Equal(t, foundModel.Config.MaxTokens, 100)
+	assert.Equal(t, foundModel.Config.Temperature, float32(0.5))
+	assert.Equal(t, foundModel.Config.TopP, float32(0.9))
+	assert.Equal(t, foundModel.Config.ModelName, "anthropic.claude-3-5-sonnet-20240620-v1:0")
+}

--- a/pkg/ai/bedrock_support/completions.go
+++ b/pkg/ai/bedrock_support/completions.go
@@ -17,7 +17,12 @@ var SUPPPORTED_BEDROCK_MODELS = []string{
 	"ai21.j2-jumbo-instruct",
 	"amazon.titan-text-express-v1",
 	"amazon.nova-pro-v1:0",
+	"eu.amazon.nova-pro-v1:0",
+	"us.amazon.nova-pro-v1:0",
+	"amazon.nova-lite-v1:0",
 	"eu.amazon.nova-lite-v1:0",
+	"us.amazon.nova-lite-v1:0",
+	"anthropic.claude-3-haiku-20240307-v1:0",
 }
 
 type ICompletion interface {
@@ -91,7 +96,7 @@ type AmazonCompletion struct {
 
 func isModelSupported(modelName string) bool {
 	for _, supportedModel := range SUPPPORTED_BEDROCK_MODELS {
-		if modelName == supportedModel {
+		if strings.Contains(modelName, supportedModel) {
 			return true
 		}
 	}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # https://github.com/k8sgpt-ai/k8sgpt/issues/1442

## 📑 Description
Taking advantage of the naming conversion of the AWS Bedrock inference profile, match inference profile arn to the predefined enum of model ID

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->