### PR TITLE
feat: call bedrock with inference profile

### DIFF
--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -294,11 +294,11 @@ func (a *AmazonBedRockClient) getModelFromString(model string) (*bedrock_support
 			strings.Contains(modelConfigNameLower, modelLower) || strings.Contains(modelLower, modelConfigNameLower) {
 			// Create a copy to avoid returning a pointer to a loop variable
 			modelCopy := a.models[i]
-			// for partial match, set the model name to the input string
-			if err := validateModelArn(modelLower); err != nil {
-				return nil, err
+			// for partial match, set the model name to the input string if it is a valid ARN
+			if validateModelArn(modelLower) {
+				modelCopy.Config.ModelName = modelLower
 			}
-			modelCopy.Config.ModelName = modelLower
+
 			return &modelCopy, nil
 		}
 	}
@@ -306,13 +306,9 @@ func (a *AmazonBedRockClient) getModelFromString(model string) (*bedrock_support
 	return nil, fmt.Errorf("model '%s' not found in supported models", model)
 }
 
-func validateModelArn(model string) error {
+func validateModelArn(model string) bool {
 	var re = regexp.MustCompile(`(?m)^arn:(?P<Partition>[^:\n]*):bedrock:(?P<Region>[^:\n]*):(?P<AccountID>[^:\n]*):(?P<Ignore>(?P<ResourceType>[^:\/\n]*)[:\/])?(?P<Resource>.*)$`)
-	if re.MatchString(model) {
-		return nil
-	} else {
-		return errors.New("invalid model arn")
-	}
+	return re.MatchString(model)
 }
 
 // Configure configures the AmazonBedRockClient with the provided configuration.

--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -293,6 +293,8 @@ func (a *AmazonBedRockClient) getModelFromString(model string) (*bedrock_support
 			strings.Contains(modelConfigNameLower, modelLower) || strings.Contains(modelLower, modelConfigNameLower) {
 			// Create a copy to avoid returning a pointer to a loop variable
 			modelCopy := a.models[i]
+			// for partial match, set the model name to the input string
+			modelCopy.Config.ModelName = modelLower
 			return &modelCopy, nil
 		}
 	}

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -47,8 +47,9 @@ func TestBedrockModelConfig(t *testing.T) {
 func TestBedrockInvalidModel(t *testing.T) {
 	client := &AmazonBedRockClient{models: testModels}
 
-	_, err := client.getModelFromString("arn:aws:s3:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
-	assert.Error(t, err, "Should report error")
+	foundModel, err := client.getModelFromString("arn:aws:s3:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
+	assert.Nil(t, err, "Error should be nil")
+	assert.Equal(t, foundModel.Config.MaxTokens, 100)
 }
 
 func TestGetModelFromString(t *testing.T) {

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -41,7 +41,7 @@ func TestBedrockModelConfig(t *testing.T) {
 	assert.Equal(t, foundModel.Config.MaxTokens, 100)
 	assert.Equal(t, foundModel.Config.Temperature, float32(0.5))
 	assert.Equal(t, foundModel.Config.TopP, float32(0.9))
-	assert.Equal(t, foundModel.Config.ModelName, "anthropic.claude-3-5-sonnet-20240620-v1:0")
+	assert.Equal(t, foundModel.Config.ModelName, "arn:aws:bedrock:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
 }
 
 func TestGetModelFromString(t *testing.T) {

--- a/pkg/ai/amazonbedrock_test.go
+++ b/pkg/ai/amazonbedrock_test.go
@@ -44,6 +44,13 @@ func TestBedrockModelConfig(t *testing.T) {
 	assert.Equal(t, foundModel.Config.ModelName, "arn:aws:bedrock:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
 }
 
+func TestBedrockInvalidModel(t *testing.T) {
+	client := &AmazonBedRockClient{models: testModels}
+
+	_, err := client.getModelFromString("arn:aws:s3:us-east-1:*:inference-policy/anthropic.claude-3-5-sonnet-20240620-v1:0")
+	assert.Error(t, err, "Should report error")
+}
+
 func TestGetModelFromString(t *testing.T) {
 	client := &AmazonBedRockClient{models: testModels}
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # https://github.com/k8sgpt-ai/k8sgpt/issues/1442

## 📑 Description
In addition to matching the inference profile to the configuration of the model, we need to call bedrock with the inference profile ARN instead of the model id.  This truly uses inference profile to invokemodel

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->