### PR TITLE
fix: panic in k8sgpt auth update

### DIFF
--- a/cmd/auth/update.go
+++ b/cmd/auth/update.go
@@ -90,7 +90,7 @@ var updateCmd = &cobra.Command{
 			}
 		}
 		if !foundBackend {
-			color.Red("Error: %s does not exist in configuration file. Please use k8sgpt auth new.", args[0])
+			color.Red("Error: %s does not exist in configuration file. Please use k8sgpt auth new.", backend)
 			os.Exit(1)
 		}
 


### PR DESCRIPTION

Closes #1496

## 📑 Description
This PR fixes a panic in `k8sgpt auth update`. 

Before:
```
k8sgpt auth update -b test
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/k8sgpt-ai/k8sgpt/cmd/auth.init.func9(0x6b74ac0, {0xc000598e80, 0x0, 0x3ec6095?})
	/home/runner/work/k8sgpt/k8sgpt/cmd/auth/update.go:93 +0x6ec
github.com/spf13/cobra.(*Command).execute(0x6b74ac0, {0xc000598e60, 0x2, 0x2})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x6b733c0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/k8sgpt-ai/k8sgpt/cmd.Execute({0x451ed84?, 0x0?}, {0x451f4a8?, 0x68e7480?}, {0x3ecb62f?, 0xc0000061c0?})
	/home/runner/work/k8sgpt/k8sgpt/cmd/root.go:65 +0x139
main.main()
	/home/runner/work/k8sgpt/k8sgpt/main.go:25 +0x3d
```

After:
```
k8sgpt auth update -b test
Error: test does not exist in configuration file. Please use k8sgpt auth new.
```

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
