### PR TITLE
fix: align documentation to reflect default analyzers properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ you will be able to write your own analyzers.
 - [x] nodeAnalyzer
 - [x] mutatingWebhookAnalyzer
 - [x] validatingWebhookAnalyzer
+- [x] configMapAnalyzer
 
 #### Optional
 
@@ -268,7 +269,6 @@ you will be able to write your own analyzers.
 - [x] logAnalyzer
 - [x] storageAnalyzer
 - [x] securityAnalyzer
-- [x] configMapAnalyzer
 
 ## Examples
 


### PR DESCRIPTION

## 📑 Description
The `ConfigMap` analyzer is part of [the default analyzers](https://github.com/k8sgpt-ai/k8sgpt/blob/34ff645fa0964ff32b17e3d859f5aa8220c15867/pkg/analyzer/analyzer.go#L46), the documentation does not reflect that properly. 

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->