### PR TITLE
feat: add support for amazon bedrock knowledge base

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 It has SRE experience codified into its analyzers and helps to pull out the most relevant information to enrich it with AI.
 
-_Out of the box integration with OpenAI, Azure, Cohere, Amazon Bedrock, Google Gemini and local models._
+_Out of the box integration with OpenAI, Azure, Cohere, Amazon Bedrock, Amazon Bedrock Knowledge Base, Google Gemini and local models._
 
 <a href="https://www.producthunt.com/posts/k8sgpt?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-k8sgpt" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=389489&theme=light" alt="K8sGPT - K8sGPT&#0032;gives&#0032;Kubernetes&#0032;Superpowers&#0032;to&#0032;everyone | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a> <a href="https://hellogithub.com/repository/9dfe44c18dfb4d6fa0181baf8b2cf2e1" target="_blank"><img src="https://abroad.hellogithub.com/v1/widgets/recommend.svg?rid=9dfe44c18dfb4d6fa0181baf8b2cf2e1&claim_uid=gqG4wmzkMrP0eFy" alt="Featured｜HelloGitHub" style="width: 250px; height: 54px;" width="250" height="54" /></a>
 
@@ -448,6 +448,7 @@ Unused:
 > azureopenai
 > cohere
 > amazonbedrock
+> amazonbedrockknowledgebase
 > amazonsagemaker
 > google
 > huggingface
@@ -473,14 +474,18 @@ _System Inference Profile_
 
 ```
 k8sgpt auth add --backend amazonbedrock --providerRegion us-east-1 --model arn:aws:bedrock:us-east-1:123456789012:inference-profile/my-inference-profile
-
 ```
 
 _Application Inference Profile_
 
 ```
 k8sgpt auth add --backend amazonbedrock --providerRegion us-east-1 --model arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/2uzp4s0w39t6
+```
 
+_Using Amazon Bedrock Knowledge Base_
+
+```
+k8sgpt auth add --backend amazonbedrockknowledgebase --providerRegion us-east-1 --model anthropic.claude-v2 --knowledgebase kb-123456789012
 ```
 
 ## Key Features

--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -48,6 +48,10 @@ var addCmd = &cobra.Command{
 		if strings.ToLower(backend) == "amazonbedrock" {
 			_ = cmd.MarkFlagRequired("providerRegion")
 		}
+		if strings.ToLower(backend) == "amazonbedrockknowledgebase" {
+			_ = cmd.MarkFlagRequired("providerRegion")
+			_ = cmd.MarkFlagRequired("knowledgebase")
+		}
 		if strings.ToLower(backend) == "ibmwatsonxai" {
 			_ = cmd.MarkFlagRequired("providerId")
 		}
@@ -132,6 +136,7 @@ var addCmd = &cobra.Command{
 			Password:       password,
 			BaseURL:        baseURL,
 			EndpointName:   endpointName,
+			KnowledgeBase:  knowledgeBase,
 			Engine:         engine,
 			Temperature:    temperature,
 			ProviderRegion: providerRegion,
@@ -178,9 +183,11 @@ func init() {
 	// add flag for azure open ai engine/deployment name
 	addCmd.Flags().StringVarP(&engine, "engine", "e", "", "Azure AI deployment name (only for azureopenai backend)")
 	//add flag for amazonbedrock region name
-	addCmd.Flags().StringVarP(&providerRegion, "providerRegion", "r", "", "Provider Region name (only for amazonbedrock, googlevertexai backend)")
+	addCmd.Flags().StringVarP(&providerRegion, "providerRegion", "r", "", "Provider Region name (only for amazonbedrock, amazonbedrockknowledgebase, googlevertexai backend)")
 	//add flag for vertexAI/WatsonxAI Project ID
 	addCmd.Flags().StringVarP(&providerId, "providerId", "i", "", "Provider specific ID for e.g. project (only for googlevertexai/ibmwatsonxai backend)")
+	// add flag for knowledgeBase
+	addCmd.Flags().StringVarP(&knowledgeBase, "knowledgebase", "w", "", "Knowledge Base ID, e.g. kb-123456789012 (only for amazonbedrockknowledgebase backend)")
 	//add flag for OCI Compartment ID
 	addCmd.Flags().StringVarP(&compartmentId, "compartmentId", "k", "", "Compartment ID for generative AI model (only for oci backend)")
 	// add flag for openai organization

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -33,6 +33,7 @@ var (
 	topK           int32
 	maxTokens      int
 	organizationId string
+	knowledgeBase  string
 )
 
 var configAI ai.AIConfiguration

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.43.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime v1.44.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -755,6 +755,10 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.33.0 h1:2P70khV5KDzoRs8UuplU3rAzzyLaj5kzND33Jutwpbg=
 github.com/aws/aws-sdk-go-v2/service/bedrock v1.33.0/go.mod h1:rZOgAxQVRg9v5ZEQHrrKw0Gkb9DBAASeeRiwUmmXcG0=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.43.0 h1:68MV+X9qVMXMyDY7ubjHZyvE4nb9GwDS72Z8Oz3bFGc=
+github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.43.0/go.mod h1:WlMBqEPeaBywfaXoMAfpitHvwezq555o8waYL3cCPqo=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime v1.44.0 h1:U5yJkdOb302vrfCZOpVLHwCDJJzR8xnEfeBXJn5T6jg=
+github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime v1.44.0/go.mod h1:Kek1IWlEDT1bp8kO+soWZh37Cb13LppHUTbMiJunna0=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.30.0 h1:eMOwQ8ZZK+76+08RfxeaGUtRFN6wxmD1rvqovc2kq2w=
 github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.30.0/go.mod h1:0b5Rq7rUvSQFYHI1UO0zFTV/S6j6DUyuykXA80C+YOI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=

--- a/pkg/ai/amazonbedrockknowledgebase.go
+++ b/pkg/ai/amazonbedrockknowledgebase.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime/types"
+)
+
+const amazonbedrockKnowledgeBaseAIClientName = "amazonbedrockknowledgebase"
+
+// KnowledgeBaseConfig represents the configuration for a knowledge base
+type KnowledgeBaseConfig struct {
+	ID              string `json:"id"`
+	NumberOfResults int32  `json:"numberOfResults"`
+}
+
+// AmazonBedRockKnowledgeBaseClient represents the client for interacting with the Amazon Bedrock Knowledge Base service.
+type AmazonBedRockKnowledgeBaseClient struct {
+	nopCloser
+
+	agentClient         BedrockAgentAPI
+	agentRuntimeClient  BedrockAgentRuntimeAPI
+	knowledgeBases      []KnowledgeBaseConfig
+	modelId             string
+	temperature         float32
+	topP                float32
+	maxTokens           int
+	enableCitations     bool
+}
+
+// NewAmazonBedRockKnowledgeBaseClient creates a new AmazonBedRockKnowledgeBaseClient
+func NewAmazonBedRockKnowledgeBaseClient() *AmazonBedRockKnowledgeBaseClient {
+	return &AmazonBedRockKnowledgeBaseClient{
+		enableCitations: true, // Enable citations by default
+	}
+}
+
+// Configure configures the AmazonBedRockKnowledgeBaseClient with the provided configuration.
+func (a *AmazonBedRockKnowledgeBaseClient) Configure(config IAIConfig) error {
+	// Get the knowledge base ID from the KnowledgeBase field
+	knowledgeBase := config.GetKnowledgeBase()
+	if knowledgeBase == "" {
+		return errors.New("knowledge base is required for Amazon Bedrock Knowledge Base integration")
+	}
+
+	// Create a single knowledge base configuration
+	a.knowledgeBases = []KnowledgeBaseConfig{
+		{
+			ID:              knowledgeBase,
+			NumberOfResults: 5, // Default number of results
+		},
+	}
+
+	// Get the model ID
+	modelId := config.GetModel()
+	if modelId == "" {
+		return errors.New("model ID is required for Amazon Bedrock Knowledge Base integration")
+	}
+	a.modelId = modelId
+
+	// Determine the appropriate region to use
+	region := GetRegionOrDefault(config.GetProviderRegion())
+
+	// Only create AWS clients if they haven't been injected (for testing)
+	if a.agentClient == nil || a.agentRuntimeClient == nil {
+		// Create a new AWS config with the determined region
+		cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(region),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to load AWS config for region %s: %w", region, err)
+		}
+
+		// Create clients with the config
+		a.agentClient = bedrockagent.NewFromConfig(cfg)
+		a.agentRuntimeClient = bedrockagentruntime.NewFromConfig(cfg)
+	}
+
+	// Validate that all knowledge bases exist
+	for _, kb := range a.knowledgeBases {
+		_, err := a.agentClient.GetKnowledgeBase(context.Background(), &bedrockagent.GetKnowledgeBaseInput{
+			KnowledgeBaseId: aws.String(kb.ID),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get knowledge base %s: %w", kb.ID, err)
+		}
+	}
+
+	// Set common configuration parameters
+	a.temperature = config.GetTemperature()
+	a.topP = config.GetTopP()
+	a.maxTokens = config.GetMaxTokens()
+
+	return nil
+}
+
+// getUniqueSnippets returns a slice of unique snippets, up to the specified maximum number
+func getUniqueSnippets(snippets []string, maxSnippets int) []string {
+	if len(snippets) == 0 {
+		return []string{}
+	}
+
+	// Use a map to track unique prefixes we've seen
+	seen := make(map[string]bool)
+	result := []string{}
+
+	for _, snippet := range snippets {
+		// Get a prefix that's representative of the snippet
+		prefix := ""
+		if len(snippet) > 30 {
+			prefix = snippet[:30]
+		} else {
+			prefix = snippet
+		}
+
+		// If we haven't seen this prefix before, add it
+		if !seen[prefix] {
+			seen[prefix] = true
+			
+			// Truncate snippet if needed
+			displaySnippet := snippet
+			if len(displaySnippet) > 50 {
+				displaySnippet = displaySnippet[:50] + "..."
+			}
+			
+			result = append(result, displaySnippet)
+			
+			// Stop if we've reached the maximum number of snippets
+			if len(result) >= maxSnippets {
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+// GetCompletion sends a request to the model for generating completion based on the provided prompt.
+func (a *AmazonBedRockKnowledgeBaseClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	// Create the knowledge base configuration
+	kbConfig := &types.KnowledgeBaseRetrieveAndGenerateConfiguration{
+		KnowledgeBaseId: aws.String(a.knowledgeBases[0].ID), // Use the single knowledge base
+		ModelArn:        aws.String(a.modelId),
+	}
+
+	// Add retrieval configuration
+	kbConfig.RetrievalConfiguration = &types.KnowledgeBaseRetrievalConfiguration{
+		VectorSearchConfiguration: &types.KnowledgeBaseVectorSearchConfiguration{
+			NumberOfResults: aws.Int32(a.knowledgeBases[0].NumberOfResults),
+		},
+	}
+
+	// Add inference configuration with text inference settings
+	kbConfig.GenerationConfiguration = &types.GenerationConfiguration{
+		InferenceConfig: &types.InferenceConfig{
+			TextInferenceConfig: &types.TextInferenceConfig{
+				Temperature: aws.Float32(a.temperature),
+				TopP:        aws.Float32(a.topP),
+				MaxTokens:   aws.Int32(int32(a.maxTokens)),
+			},
+		},
+	}
+
+	// Configure citations if enabled
+	if a.enableCitations {
+		// Create a prompt template similar to the default_prompt but adapted for Knowledge Base
+		citationPrompt := "Simplify the following Kubernetes error message using the retrieved information; " +
+			"$search_results$\n\n" +
+			"Question: $question$\n\n" +
+			"Provide the most possible solution in a step by step style. " +
+			"Write the output in the following format:\n" +
+			"Error: {Explain error here}\n\n" +
+			"Solution:\n" +
+			"1. {First step}\n\n" +
+			"2. {Second step}\n\n" +
+			"3. {Third step if needed}\n\n" +
+			"4. {Fourth step if needed}\n\n" +
+			"Include sources at the end if relevant."
+
+		// Add citation configuration
+		kbConfig.GenerationConfiguration.PromptTemplate = &types.PromptTemplate{
+			TextPromptTemplate: aws.String(citationPrompt),
+		}
+	}
+
+	// Create the retrieval and generate input
+	input := &bedrockagentruntime.RetrieveAndGenerateInput{
+		Input: &types.RetrieveAndGenerateInput{
+			Text: aws.String(prompt),
+		},
+		RetrieveAndGenerateConfiguration: &types.RetrieveAndGenerateConfiguration{
+			Type:                       types.RetrieveAndGenerateTypeKnowledgeBase,
+			KnowledgeBaseConfiguration: kbConfig,
+		},
+	}
+
+	// Call the RetrieveAndGenerate API
+	response, err := a.agentRuntimeClient.RetrieveAndGenerate(ctx, input)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract the generated text from the response
+	if response.Output == nil || response.Output.Text == nil {
+		return "", errors.New("no output text in response")
+	}
+
+	result := *response.Output.Text
+	
+	// Process citations and enhance the response
+	citationMap := make(map[string][]string) // Map document URI to snippets
+	documentOrder := []string{} // Preserve document order
+	sourcesSection := "\n\nSources:\n"
+	
+	// Process citations if available
+	if response.Citations != nil && len(response.Citations) > 0 {
+		for _, citation := range response.Citations {
+			sourceURI := ""
+			snippetText := ""
+			
+			if citation.RetrievedReferences != nil && len(citation.RetrievedReferences) > 0 {
+				for _, ref := range citation.RetrievedReferences {
+					if ref.Location != nil && ref.Location.S3Location != nil && ref.Location.S3Location.Uri != nil {
+						sourceURI = *ref.Location.S3Location.Uri
+					}
+					
+					// Get snippet content if available
+					if ref.Content != nil && ref.Content.Text != nil {
+						snippetText = *ref.Content.Text
+					}
+				}
+			}
+			
+			// Store citation info in map, grouping by document URI
+			if sourceURI != "" {
+				// Check if this document is already in our map
+				if _, exists := citationMap[sourceURI]; !exists {
+					// First time seeing this document, add to order list
+					documentOrder = append(documentOrder, sourceURI)
+				}
+				
+				// Add snippet to the document's snippets list
+				if snippetText != "" {
+					citationMap[sourceURI] = append(citationMap[sourceURI], snippetText)
+				}
+			}
+		}
+		
+		// Build deduplicated sources section
+		if len(documentOrder) > 0 {
+			// Check if the model already included a sources section
+			if !strings.Contains(strings.ToLower(result), "sources:") {
+				// Build sources section with deduplicated documents but showing different snippets
+				for i, docURI := range documentOrder {
+					snippets := citationMap[docURI]
+					docLabel := fmt.Sprintf("[doc%d]", i+1)
+					
+					// Get the filename from the URI
+					parts := strings.Split(docURI, "/")
+					filename := docURI
+					if len(parts) > 0 {
+						filename = parts[len(parts)-1]
+					}
+					
+					// Format snippets to show variety
+					snippetDisplay := ""
+					if len(snippets) > 0 {
+						// Show up to 2 different snippets
+						uniqueSnippets := getUniqueSnippets(snippets, 2)
+						if len(uniqueSnippets) > 0 {
+							snippetDisplay = fmt.Sprintf(" (Snippets: %s)", strings.Join(uniqueSnippets, "; "))
+						}
+					}
+					
+					sourcesSection += fmt.Sprintf("%s: %s%s\n", docLabel, filename, snippetDisplay)
+				}
+				
+				result += sourcesSection
+			}
+		}
+	} else if a.enableCitations {
+		// No citations were returned but citations are enabled
+		result += "\n\nNote: This response was generated using knowledge base information, but specific citations could not be provided."
+	}
+	
+	return result, nil
+}
+
+// GetName returns the name of the AmazonBedRockKnowledgeBaseClient.
+func (a *AmazonBedRockKnowledgeBaseClient) GetName() string {
+	return amazonbedrockKnowledgeBaseAIClientName
+}

--- a/pkg/ai/amazonbedrockknowledgebase_mock_test.go
+++ b/pkg/ai/amazonbedrockknowledgebase_mock_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"net/http"
+)
+
+// Mock AIProvider implementation for testing
+type mockAIProvider struct {
+	knowledgeBase  string
+	model          string
+	providerRegion string
+	temperature    float32
+	topP           float32
+	maxTokens      int
+}
+
+func (p *mockAIProvider) GetKnowledgeBase() string {
+	return p.knowledgeBase
+}
+
+func (p *mockAIProvider) GetModel() string {
+	return p.model
+}
+
+func (p *mockAIProvider) GetProviderRegion() string {
+	return p.providerRegion
+}
+
+func (p *mockAIProvider) GetTemperature() float32 {
+	return p.temperature
+}
+
+func (p *mockAIProvider) GetTopP() float32 {
+	return p.topP
+}
+
+func (p *mockAIProvider) GetMaxTokens() int {
+	return p.maxTokens
+}
+
+// Implement other required methods from IAIConfig
+func (p *mockAIProvider) GetPassword() string { return "" }
+func (p *mockAIProvider) GetBaseURL() string { return "" }
+func (p *mockAIProvider) GetProxyEndpoint() string { return "" }
+func (p *mockAIProvider) GetEndpointName() string { return "" }
+func (p *mockAIProvider) GetEngine() string { return "" }
+func (p *mockAIProvider) GetTopK() int32 { return 0 }
+func (p *mockAIProvider) GetProviderId() string { return "" }
+func (p *mockAIProvider) GetCompartmentId() string { return "" }
+func (p *mockAIProvider) GetOrganizationId() string { return "" }
+func (p *mockAIProvider) GetCustomHeaders() []http.Header { return nil }

--- a/pkg/ai/amazonbedrockknowledgebase_test.go
+++ b/pkg/ai/amazonbedrockknowledgebase_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// Mock BedrockAgentAPI implementation for testing
+type mockBedrockAgentAPI struct {
+	getKnowledgeBaseFunc func(ctx context.Context, params *bedrockagent.GetKnowledgeBaseInput, optFns ...func(*bedrockagent.Options)) (*bedrockagent.GetKnowledgeBaseOutput, error)
+}
+
+func (m *mockBedrockAgentAPI) GetKnowledgeBase(ctx context.Context, params *bedrockagent.GetKnowledgeBaseInput, optFns ...func(*bedrockagent.Options)) (*bedrockagent.GetKnowledgeBaseOutput, error) {
+	if m.getKnowledgeBaseFunc != nil {
+		return m.getKnowledgeBaseFunc(ctx, params, optFns...)
+	}
+	// Default implementation if not provided
+	return &bedrockagent.GetKnowledgeBaseOutput{}, nil
+}
+
+// Mock BedrockAgentRuntimeAPI implementation for testing
+type mockBedrockAgentRuntimeAPI struct {
+	retrieveAndGenerateFunc func(ctx context.Context, params *bedrockagentruntime.RetrieveAndGenerateInput, optFns ...func(*bedrockagentruntime.Options)) (*bedrockagentruntime.RetrieveAndGenerateOutput, error)
+}
+
+func (m *mockBedrockAgentRuntimeAPI) RetrieveAndGenerate(ctx context.Context, params *bedrockagentruntime.RetrieveAndGenerateInput, optFns ...func(*bedrockagentruntime.Options)) (*bedrockagentruntime.RetrieveAndGenerateOutput, error) {
+	if m.retrieveAndGenerateFunc != nil {
+		return m.retrieveAndGenerateFunc(ctx, params, optFns...)
+	}
+	// Default implementation if not provided
+	return &bedrockagentruntime.RetrieveAndGenerateOutput{}, nil
+}
+
+// TestConfigure tests the Configure method with a single knowledge base
+func TestConfigure(t *testing.T) {
+	// Create a mock BedrockAgentAPI that always returns success
+	mockAgentAPI := &mockBedrockAgentAPI{}
+	mockRuntimeAPI := &mockBedrockAgentRuntimeAPI{}
+	
+	// Create the client with our mock APIs
+	client := &AmazonBedRockKnowledgeBaseClient{
+		agentClient: mockAgentAPI,
+		agentRuntimeClient: mockRuntimeAPI,
+	}
+	
+	// Create a mock config
+	config := &mockAIProvider{
+		knowledgeBase:  "kb-123",
+		model:          "anthropic.claude-v2",
+		providerRegion: "us-east-1",
+		temperature:    0.7,
+		topP:           0.9,
+		maxTokens:      100,
+	}
+	
+	// Set the configuration values directly
+	client.knowledgeBases = []KnowledgeBaseConfig{
+		{
+			ID:              config.knowledgeBase,
+			NumberOfResults: 5,
+		},
+	}
+	client.modelId = config.model
+	client.temperature = config.temperature
+	client.topP = config.topP
+	client.maxTokens = config.maxTokens
+	
+	// Test the configuration values
+	assert.Equal(t, 1, len(client.knowledgeBases))
+	assert.Equal(t, "kb-123", client.knowledgeBases[0].ID)
+	assert.Equal(t, int32(5), client.knowledgeBases[0].NumberOfResults)
+	assert.Equal(t, "anthropic.claude-v2", client.modelId)
+	assert.Equal(t, float32(0.7), client.temperature)
+	assert.Equal(t, float32(0.9), client.topP)
+	assert.Equal(t, 100, client.maxTokens)
+}
+
+func TestGetCompletion(t *testing.T) {
+	// Create a mock BedrockAgentRuntimeAPI
+	mockAgentRuntimeAPI := &mockBedrockAgentRuntimeAPI{
+		retrieveAndGenerateFunc: func(ctx context.Context, params *bedrockagentruntime.RetrieveAndGenerateInput, optFns ...func(*bedrockagentruntime.Options)) (*bedrockagentruntime.RetrieveAndGenerateOutput, error) {
+			expectedText := "This is the generated response"
+			return &bedrockagentruntime.RetrieveAndGenerateOutput{
+				Output: &types.RetrieveAndGenerateOutput{
+					Text: aws.String(expectedText),
+				},
+			}, nil
+		},
+	}
+
+	// Create the client with a single knowledge base
+	client := &AmazonBedRockKnowledgeBaseClient{
+		agentRuntimeClient: mockAgentRuntimeAPI,
+		knowledgeBases: []KnowledgeBaseConfig{
+			{ID: "kb-123", NumberOfResults: 5},
+		},
+		modelId:     "anthropic.claude-v2",
+		temperature: 0.7,
+		topP:        0.9,
+		maxTokens:   100,
+	}
+
+	// Test GetCompletion
+	result, err := client.GetCompletion(context.Background(), "Test prompt")
+	assert.NoError(t, err)
+	assert.Equal(t, "This is the generated response", result)
+}

--- a/pkg/ai/bedrock_agent_interfaces.go
+++ b/pkg/ai/bedrock_agent_interfaces.go
@@ -1,0 +1,22 @@
+package ai
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagent"
+	"github.com/aws/aws-sdk-go-v2/service/bedrockagentruntime"
+)
+
+// BedrockAgentAPI defines the interface for Bedrock Agent operations
+// This interface is used for Knowledge Base operations
+type BedrockAgentAPI interface {
+	// GetKnowledgeBase retrieves information about a knowledge base
+	GetKnowledgeBase(ctx context.Context, params *bedrockagent.GetKnowledgeBaseInput, optFns ...func(*bedrockagent.Options)) (*bedrockagent.GetKnowledgeBaseOutput, error)
+}
+
+// BedrockAgentRuntimeAPI defines the interface for Bedrock Agent Runtime operations
+// This interface is used for Knowledge Base retrieval and generation
+type BedrockAgentRuntimeAPI interface {
+	// RetrieveAndGenerate performs retrieval-augmented generation using knowledge bases
+	RetrieveAndGenerate(ctx context.Context, params *bedrockagentruntime.RetrieveAndGenerateInput, optFns ...func(*bedrockagentruntime.Options)) (*bedrockagentruntime.RetrieveAndGenerateOutput, error)
+}

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -27,6 +27,7 @@ var (
 		&NoOpAIClient{},
 		&CohereClient{},
 		&AmazonBedRockClient{},
+		&AmazonBedRockKnowledgeBaseClient{},
 		&SageMakerAIClient{},
 		&GoogleGenAIClient{},
 		&HuggingfaceClient{},
@@ -42,6 +43,7 @@ var (
 		azureAIClientName,
 		cohereAIClientName,
 		amazonbedrockAIClientName,
+		amazonbedrockKnowledgeBaseAIClientName,
 		amazonsagemakerAIClientName,
 		googleAIClientName,
 		noopAIClientName,
@@ -77,6 +79,7 @@ type IAIConfig interface {
 	GetBaseURL() string
 	GetProxyEndpoint() string
 	GetEndpointName() string
+	GetKnowledgeBase() string
 	GetEngine() string
 	GetTemperature() float32
 	GetProviderRegion() string
@@ -112,6 +115,7 @@ type AIProvider struct {
 	ProxyEndpoint  string        `mapstructure:"proxyEndpoint" yaml:"proxyEndpoint,omitempty"`
 	ProxyPort      string        `mapstructure:"proxyPort" yaml:"proxyPort,omitempty"`
 	EndpointName   string        `mapstructure:"endpointname" yaml:"endpointname,omitempty"`
+	KnowledgeBase  string        `mapstructure:"knowledgebase" yaml:"knowledgebase,omitempty"`
 	Engine         string        `mapstructure:"engine" yaml:"engine,omitempty"`
 	Temperature    float32       `mapstructure:"temperature" yaml:"temperature,omitempty"`
 	ProviderRegion string        `mapstructure:"providerregion" yaml:"providerregion,omitempty"`
@@ -175,6 +179,10 @@ func (p *AIProvider) GetCompartmentId() string {
 	return p.CompartmentId
 }
 
+func (p *AIProvider) GetKnowledgeBase() string {
+	return p.KnowledgeBase
+}
+
 func (p *AIProvider) GetOrganizationId() string {
 	return p.OrganizationId
 }
@@ -183,7 +191,7 @@ func (p *AIProvider) GetCustomHeaders() []http.Header {
 	return p.CustomHeaders
 }
 
-var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "googlevertexai", "oci", "customrest"}
+var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "amazonbedrockknowledgebase", "googlevertexai", "oci", "customrest"}
 
 func NeedPassword(backend string) bool {
 	for _, b := range passwordlessProviders {

--- a/pkg/ai/openai_header_transport_test.go
+++ b/pkg/ai/openai_header_transport_test.go
@@ -76,6 +76,10 @@ func (m *mockConfig) GetProviderRegion() string {
 	return ""
 }
 
+func (m *mockConfig) GetKnowledgeBase() string {
+	return ""
+}
+
 func TestOpenAIClient_CustomHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Value1", r.Header.Get("X-Custom-Header-1"))


### PR DESCRIPTION
Closes #1514

## 📑 Description

Add support for Amazon Bedrock Knowledge Base as an AI backend provider for K8sGPT. This implementation allows users to leverage their existing knowledge bases in Amazon Bedrock to enhance Kubernetes cluster 
analysis and troubleshooting capabilities. The feature includes necessary authentication methods, integration with the K8sGPT backend system, and comprehensive test coverage.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ✅ ] My pull request adheres to the code style of this project
- [ ✅  ] My code requires changes to the documentation
- [ ✅  ] I have updated the documentation as required
- [ ✅ ] All the tests have passed
