### PR TITLE
feat: add latest and legacy stable models

### DIFF
--- a/pkg/ai/googlevertexai.go
+++ b/pkg/ai/googlevertexai.go
@@ -61,10 +61,22 @@ var VERTEXAI_SUPPORTED_REGION = []string{
 }
 
 const (
-	ModelGeminiProV1 = "gemini-1.0-pro-001"
+	ModelGeminiProV1       = "gemini-1.0-pro-001"    // Retired Model
+	ModelGeminiProV2_5     = "gemini-2.5-pro"        // Latest Stable Model
+	ModelGeminiFlashV2_5   = "gemini-2.5-flash"      // Latest Stable Model
+	ModelGeminiFlashV2     = "gemini-2.0-flash"      // Latest Stable Model
+	ModelGeminiFlashLiteV2 = "gemini-2.0-flash-lite" // Latest Stable Model
+	ModelGeminiProV1_5     = "gemini-1.5-pro-002*"   // Legacy Stable Model
+	ModelGeminiFlashV1_5   = "gemini-1.5-flash-002*" // Legacy Stable Model
 )
 
 var VERTEXAI_MODELS = []string{
+	ModelGeminiProV2_5,
+	ModelGeminiFlashV2_5,
+	ModelGeminiFlashV2,
+	ModelGeminiFlashLiteV2,
+	ModelGeminiProV1_5,
+	ModelGeminiFlashV1_5,
 	ModelGeminiProV1,
 }
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Related to #1516  <!-- Issue # here -->

## 📑 Description
- Added support for latest and legacy stable models to date for the Google Vertex AI provider: 
-- gemini-2.5-pro       
-- gemini-2.5-flash     
-- gemini-2.0-flash    
-- gemini-2.0-flash-lite
-- gemini-1.5-pro-002*
-- gemini-1.5-flash-002*
- Changed default model to `gemini-2.5-pro` instead of the retired `gemini-1.0-pro-001`


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [v ] My pull request adheres to the code style of this project
- [x ] My code requires changes to the documentation
- [x ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Based on [Model versions and lifecycle webpage](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions#gemini-model-versions)