### PR TITLE
feat: add APAC region Claude models support for Amazon Bedrock

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -29,8 +29,10 @@ K8sGPT supports a variety of AI/LLM providers (backends). Some providers have a 
   - anthropic.claude-sonnet-4-20250514-v1:0
   - us.anthropic.claude-sonnet-4-20250514-v1:0
   - eu.anthropic.claude-sonnet-4-20250514-v1:0
+  - apac.anthropic.claude-sonnet-4-20250514-v1:0
   - us.anthropic.claude-3-7-sonnet-20250219-v1:0
   - eu.anthropic.claude-3-7-sonnet-20250219-v1:0
+  - apac.anthropic.claude-3-7-sonnet-20250219-v1:0
   - anthropic.claude-3-5-sonnet-20240620-v1:0
   - us.anthropic.claude-3-5-sonnet-20241022-v2:0
   - anthropic.claude-v2

--- a/pkg/ai/amazonbedrock.go
+++ b/pkg/ai/amazonbedrock.go
@@ -95,7 +95,18 @@ var defaultModels = []bedrock_support.BedrockModel{
 			ModelName:   "eu.anthropic.claude-sonnet-4-20250514-v1:0",
 		},
 	},
-
+	{
+		Name:       "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+		Completion: &bedrock_support.CohereMessagesCompletion{},
+		Response:   &bedrock_support.CohereMessagesResponse{},
+		Config: bedrock_support.BedrockModelConfig{
+			// sensible defaults
+			MaxTokens:   100,
+			Temperature: 0.5,
+			TopP:        0.9,
+			ModelName:   "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+		},
+	},
 	{
 		Name:       "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
 		Completion: &bedrock_support.CohereMessagesCompletion{},
@@ -118,6 +129,18 @@ var defaultModels = []bedrock_support.BedrockModel{
 			Temperature: 0.5,
 			TopP:        0.9,
 			ModelName:   "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		},
+	},
+	{
+		Name:       "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		Completion: &bedrock_support.CohereMessagesCompletion{},
+		Response:   &bedrock_support.CohereMessagesResponse{},
+		Config: bedrock_support.BedrockModelConfig{
+			// sensible defaults
+			MaxTokens:   100,
+			Temperature: 0.5,
+			TopP:        0.9,
+			ModelName:   "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
 		},
 	},
 	{


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1542 

## 📑 Description
This PR adds support for two new APAC region Claude models in the Amazon Bedrock AI provider to enable users in APAC regions to access the latest Claude models with improved performance and lower latency.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->