### PR TITLE
fix: sanitize quotes in CustomRest JSON parsing

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -523,6 +523,9 @@ func (a *Analysis) getAIResultForSanitizedFailures(texts []string, promptTmpl st
 		}
 	}
 
+	if a.AIClient.GetName() == ai.CustomRestClientName {
+		inputKey = strings.ReplaceAll(inputKey, `"`, "'")
+	}
 	// Process template.
 	prompt := fmt.Sprintf(strings.TrimSpace(promptTmpl), a.Language, inputKey)
 	if a.AIClient.GetName() == ai.CustomRestClientName {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Kubernetes error messages containing quotes break JSON unmarshalling in CustomRest client, causing 'invalid character after object key:value pair' errors.

This change sanitizes quotes in both message and prompt fields before JSON parsing by replacing double quotes with single quotes.

Only affects CustomRest client - other AI providers are unaffected.

Fixes #1556

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->