### PR TITLE
feat: add Groq as LLM provider

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -75,6 +75,9 @@ K8sGPT supports a variety of AI/LLM providers (backends). Some providers have a 
 - **Supported Models:**
   - ibm/granite-13b-chat-v2
 
+### Groq
+- **Model:** User-configurable (any model supported by Groq, e.g., `llama-3.3-70b-versatile`, `mixtral-8x7b-32768`)
+
 ---
 
 For more details on configuring each provider and model, refer to the official K8sGPT documentation and the provider's own documentation. 

--- a/pkg/ai/groq.go
+++ b/pkg/ai/groq.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+const groqAIClientName = "groq"
+
+// Default Groq API endpoint (OpenAI-compatible)
+const groqAPIBaseURL = "https://api.groq.com/openai/v1"
+
+type GroqClient struct {
+	nopCloser
+
+	client      *openai.Client
+	model       string
+	temperature float32
+	topP        float32
+}
+
+func (c *GroqClient) Configure(config IAIConfig) error {
+	token := config.GetPassword()
+	defaultConfig := openai.DefaultConfig(token)
+	proxyEndpoint := config.GetProxyEndpoint()
+
+	baseURL := config.GetBaseURL()
+	if baseURL != "" {
+		defaultConfig.BaseURL = baseURL
+	} else {
+		defaultConfig.BaseURL = groqAPIBaseURL
+	}
+
+	transport := &http.Transport{}
+	if proxyEndpoint != "" {
+		proxyUrl, err := url.Parse(proxyEndpoint)
+		if err != nil {
+			return err
+		}
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+
+	customHeaders := config.GetCustomHeaders()
+	defaultConfig.HTTPClient = &http.Client{
+		Transport: &OpenAIHeaderTransport{
+			Origin:  transport,
+			Headers: customHeaders,
+		},
+	}
+
+	client := openai.NewClientWithConfig(defaultConfig)
+	if client == nil {
+		return errors.New("error creating Groq client")
+	}
+	c.client = client
+	c.model = config.GetModel()
+	c.temperature = config.GetTemperature()
+	c.topP = config.GetTopP()
+	return nil
+}
+
+func (c *GroqClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: c.model,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+		Temperature:      c.temperature,
+		MaxTokens:        maxToken,
+		PresencePenalty:  presencePenalty,
+		FrequencyPenalty: frequencyPenalty,
+		TopP:             c.topP,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (c *GroqClient) GetName() string {
+	return groqAIClientName
+}

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -34,6 +34,7 @@ var (
 		&OCIGenAIClient{},
 		&CustomRestClient{},
 		&IBMWatsonxAIClient{},
+		&GroqClient{},
 	}
 	Backends = []string{
 		openAIClientName,
@@ -50,6 +51,7 @@ var (
 		ociClientName,
 		CustomRestClientName,
 		ibmWatsonxAIClientName,
+		groqAIClientName,
 	}
 )
 


### PR DESCRIPTION
## Summary
This PR adds Groq as a new AI backend provider for k8sgpt.

Fixes #1269

## Changes
- Added new `GroqClient` implementation in `pkg/ai/groq.go`
- Registered Groq client in `pkg/ai/iai.go` (clients list and Backends list)
- Updated `SUPPORTED_MODELS.md` to document Groq provider

## Implementation Details
Groq provides an OpenAI-compatible API, so this implementation reuses the existing `go-openai` client library with Groq's API endpoint (`https://api.groq.com/openai/v1`). The implementation follows the same pattern as other OpenAI-compatible providers in the codebase.

## Test Plan
- [x] Build passes: `go build ./...`
- [x] All tests pass: `go test ./...`
- [x] Code is properly formatted with gofmt

🤖 Generated with [Claude Code](https://claude.com/claude-code)