### PR TITLE
fix: use MaxCompletionTokens instead of deprecated MaxTokens for OpenAI

### DIFF
--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -95,7 +95,7 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 			},
 		},
 		Temperature:      c.temperature,
-		MaxTokens:        maxToken,
+		MaxCompletionTokens: maxToken,
 		PresencePenalty:  presencePenalty,
 		FrequencyPenalty: frequencyPenalty,
 		TopP:             c.topP,


### PR DESCRIPTION
Closes #

## 📑 Description

The OpenAI API deprecated the `max_tokens` parameter in favor of `max_completion_tokens` for newer models (o1, gpt-4o, gpt-5, etc.).

This PR fixes the following error when using newer OpenAI models:
```
Error: failed while calling AI provider openai: error, status code: 400, status: 400 Bad Request, 
message: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

The `go-openai` library (v1.36.0) already supports the `MaxCompletionTokens` field in `ChatCompletionRequest`.

Reference: https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

**Before:** Using `MaxTokens` parameter (deprecated)
**After:** Using `MaxCompletionTokens` parameter (current standard)

This is a backward-compatible change as the `go-openai` library handles both parameters correctly for older and newer models.