### PR TITLE
feat: add resources analyzer for missing requests/limits

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -56,6 +56,7 @@ var additionalAnalyzerMap = map[string]common.IAnalyzer{
 	"Gateway":                 GatewayAnalyzer{},
 	"HTTPRoute":               HTTPRouteAnalyzer{},
 	"Storage":                 StorageAnalyzer{},
+	"Resources":               ResourcesAnalyzer{},
 	"Security":                SecurityAnalyzer{},
 	"ClusterCatalog":          ClusterCatalogAnalyzer{},
 	"ClusterExtension":        ClusterExtensionAnalyzer{},

--- a/pkg/analyzer/resources.go
+++ b/pkg/analyzer/resources.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ResourcesAnalyzer checks for missing CPU/memory requests/limits on workload containers.
+//
+// This intentionally starts with Deployments only (safe, small surface) and can be extended
+// to other workload kinds in follow-up PRs.
+type ResourcesAnalyzer struct{}
+
+func (ResourcesAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
+	kind := "Resources"
+
+	AnalyzerErrorsMetric.DeletePartialMatch(map[string]string{
+		"analyzer_name": kind,
+	})
+
+	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(a.Context, metav1.ListOptions{
+		LabelSelector: a.LabelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var preAnalysis = map[string]common.PreAnalysis{}
+
+	for _, deployment := range deployments.Items {
+		var failures []common.Failure
+
+		containers := deployment.Spec.Template.Spec.Containers
+		initContainers := deployment.Spec.Template.Spec.InitContainers
+
+		failures = append(failures, resourcesFailuresForContainers("container", deployment.Namespace, deployment.Name, containers)...)
+		failures = append(failures, resourcesFailuresForContainers("initContainer", deployment.Namespace, deployment.Name, initContainers)...)
+
+		if len(failures) > 0 {
+			preAnalysis[fmt.Sprintf("%s/%s", deployment.Namespace, deployment.Name)] = common.PreAnalysis{
+				FailureDetails: failures,
+				Deployment:     deployment,
+			}
+			AnalyzerErrorsMetric.WithLabelValues(kind, deployment.Name, deployment.Namespace).Set(float64(len(failures)))
+		}
+	}
+
+	for key, value := range preAnalysis {
+		a.Results = append(a.Results, common.Result{
+			Kind:  kind,
+			Name:  key,
+			Error: value.FailureDetails,
+		})
+	}
+
+	return a.Results, nil
+}
+
+func resourcesFailuresForContainers(containerType, namespace, deploymentName string, containers []corev1.Container) []common.Failure {
+	var failures []common.Failure
+
+	for _, c := range containers {
+		missing := missingResourceFields(c)
+		if len(missing) == 0 {
+			continue
+		}
+
+		failures = append(failures, common.Failure{
+			Text: fmt.Sprintf(
+				"%s %s in Deployment %s/%s is missing resource settings: %s. Add CPU/memory requests and limits to improve scheduling stability and reduce eviction/noisy-neighbor issues.",
+				containerType,
+				c.Name,
+				namespace,
+				deploymentName,
+				strings.Join(missing, ", "),
+			),
+			Sensitive: []common.Sensitive{
+				{
+					Unmasked: namespace,
+					Masked:   util.MaskString(namespace),
+				},
+				{
+					Unmasked: deploymentName,
+					Masked:   util.MaskString(deploymentName),
+				},
+				{
+					Unmasked: c.Name,
+					Masked:   util.MaskString(c.Name),
+				},
+			},
+		})
+	}
+
+	return failures
+}
+
+func missingResourceFields(c corev1.Container) []string {
+	var missing []string
+
+	req := c.Resources.Requests
+	lim := c.Resources.Limits
+
+	if req == nil || req.Cpu().IsZero() {
+		missing = append(missing, "requests.cpu")
+	}
+	if req == nil || req.Memory().IsZero() {
+		missing = append(missing, "requests.memory")
+	}
+	if lim == nil || lim.Cpu().IsZero() {
+		missing = append(missing, "limits.cpu")
+	}
+	if lim == nil || lim.Memory().IsZero() {
+		missing = append(missing, "limits.memory")
+	}
+
+	return missing
+}

--- a/pkg/analyzer/resources_test.go
+++ b/pkg/analyzer/resources_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestResourcesAnalyzer(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-no-resources",
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "api",
+							},
+						},
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-requests-only",
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "api",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-requests-and-limits",
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "api",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("500m"),
+										corev1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	resourcesAnalyzer := ResourcesAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	results, err := resourcesAnalyzer.Analyze(config)
+	require.NoError(t, err)
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+
+	require.Len(t, results, 2)
+	require.Equal(t, "default/dep-no-resources", results[0].Name)
+	require.Equal(t, "Resources", results[0].Kind)
+	require.Len(t, results[0].Error, 1)
+	require.Contains(t, results[0].Error[0].Text, "missing resource settings")
+
+	require.Equal(t, "default/dep-requests-only", results[1].Name)
+	require.Equal(t, "Resources", results[1].Kind)
+	require.Len(t, results[1].Error, 1)
+	require.Contains(t, results[1].Error[0].Text, "limits.cpu")
+	require.Contains(t, results[1].Error[0].Text, "limits.memory")
+}


### PR DESCRIPTION
## 📑 Description
<!-- Adds a new Resources analyzer that reports Deployments whose containers (including initContainers) are missing CPU/memory requests and/or limits. This helps catch common scheduling and stability issues caused by unset resource requirements. -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed (go test ./pkg/analyzer -v)

## ℹ Additional Information
<!-- 
Analyzer is registered as filter Resources in pkg/analyzer/analyzer.go.
Current scope: Deployments only (can be extended to StatefulSets/DaemonSets/Jobs in a follow-up PR).
-->