### PR TITLE
fix: align CI Go versions with go.mod to ensure consistency

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -14,7 +14,7 @@ on:
       - "**.md"
 
 env:
-  GO_VERSION: "~1.23"
+  GO_VERSION: "~1.24"
   IMAGE_NAME: "k8sgpt"
   REGISTRY_IMAGE: ghcr.io/k8sgpt-ai/k8sgpt
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: '1.22'
+          go-version: '~1.24'
       - name: Download Syft
         uses: anchore/sbom-action/download-syft@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
       - name: Run GoReleaser

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "~1.22"
+  GO_VERSION: "~1.24"
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #1610

## Problem

The CI workflows were using inconsistent Go versions that don't match `go.mod`:
- `go.mod` declares: `go 1.24.1` with `toolchain go1.24.11`
- `test.yaml` was using: `GO_VERSION: "~1.22"`
- `build_container.yaml` was using: `GO_VERSION: "~1.23"`
- `release.yaml` was using: `go-version: '1.22'`

This creates:
- Confusion for contributors about which Go version to use
- Risk of version-specific bugs that only appear in certain workflows
- Inconsistent build/test results

## Solution

Align all CI workflows to use `~1.24` to match `go.mod`'s declared version.

## Changes

- **test.yaml**: `GO_VERSION` from `~1.22` to `~1.24`
- **build_container.yaml**: `GO_VERSION` from `~1.23` to `~1.24`
- **release.yaml**: `go-version` from `1.22` to `~1.24`

## Related

- Aligns with PR #1609 which updates CONTRIBUTING.md to reflect Go 1.24 requirement
- Similar fix applied to k8sgpt-operator repo (#793)

## Testing

All CI workflows should continue to pass with the updated Go version, now consistent with `go.mod`.