### PR TITLE
feat: add short flag and env var for metrics port

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -203,6 +203,11 @@ var ServeCmd = &cobra.Command{
 			}()
 		}
 
+		// Allow metrics port to be overridden by environment variable
+		if envMetricsPort := os.Getenv("K8SGPT_METRICS_PORT"); envMetricsPort != "" && !cmd.Flags().Changed("metrics-port") {
+			metricsPort = envMetricsPort
+		}
+
 		server := k8sgptserver.Config{
 			Backend:     aiProvider.Name,
 			Port:        port,
@@ -234,7 +239,7 @@ var ServeCmd = &cobra.Command{
 func init() {
 	// add flag for backend
 	ServeCmd.Flags().StringVarP(&port, "port", "p", "8080", "Port to run the server on")
-	ServeCmd.Flags().StringVarP(&metricsPort, "metrics-port", "", "8081", "Port to run the metrics-server on")
+	ServeCmd.Flags().StringVarP(&metricsPort, "metrics-port", "m", "8081", "Port to run the metrics-server on (env: K8SGPT_METRICS_PORT)")
 	ServeCmd.Flags().StringVarP(&backend, "backend", "b", "openai", "Backend AI provider")
 	ServeCmd.Flags().BoolVarP(&enableHttp, "http", "", false, "Enable REST/http using gppc-gateway")
 	ServeCmd.Flags().BoolVarP(&enableMCP, "mcp", "", false, "Enable Mission Control Protocol server")


### PR DESCRIPTION
## Summary

Improves discoverability and configurability of the metrics server port.

### Changes

- **Short flag `-m`** added for `--metrics-port` — users can now use `k8sgpt serve -p 8880 -m 9090 --mcp` instead of the longer form
- **Environment variable `K8SGPT_METRICS_PORT`** support added, consistent with existing `K8SGPT_*` env vars (`K8SGPT_TEMPERATURE`, `K8SGPT_BACKEND`, etc.)
- CLI flag takes precedence over env var

### Motivation

Users running `k8sgpt serve` with `--mcp` or other configurations may encounter port conflicts on the default metrics port (8081). While `--metrics-port` already exists, it was not easily discoverable (no short flag, no env var support). This was reported in the k8sgpt Slack community.

### Usage

```bash
# Short flag
k8sgpt serve -p 8880 -m 9090 --mcp

# Environment variable
export K8SGPT_METRICS_PORT=9090
k8sgpt serve -p 8880 --mcp

# Long flag (unchanged)
k8sgpt serve -p 8880 --metrics-port 9090 --mcp
```

Signed-off-by: Three Foxes (in a Trenchcoat) <threefoxes53235@gmail.com>