### PR TITLE
fix: amazonbedrockconverse claude models temp and topp

### DIFF
--- a/pkg/ai/amazonbedrockconverse.go
+++ b/pkg/ai/amazonbedrockconverse.go
@@ -61,6 +61,11 @@ func processError(err error, modelId string) error {
 	}
 }
 
+func isClaudeModel(modelId string) bool {
+	m := strings.ToLower(modelId)
+	return strings.Contains(m, "claude")
+}
+
 func (a *AmazonBedrockConverseClient) Configure(config IAIConfig) error {
 	modelInput := config.GetModel()
 
@@ -133,15 +138,22 @@ func (a *AmazonBedrockConverseClient) GetCompletion(ctx context.Context, prompt 
 		Content: []types.ContentBlock{&content},
 		Role:    "user",
 	}
+
+	var infConfig = &types.InferenceConfiguration{
+		MaxTokens:     aws.Int32(int32(a.maxTokens)),
+		StopSequences: a.stopSequences,
+	}
+
+	// Claude models only support temperature OR topP, while others support both temperature and topP. Prefer temperature for now
+	if !isClaudeModel(a.model) {
+		infConfig.TopP = aws.Float32(a.topP)
+	}
+	infConfig.Temperature = aws.Float32(a.temperature)
+		
 	var converseInput = bedrockruntime.ConverseInput{
 		ModelId:  aws.String(a.model),
 		Messages: []types.Message{message},
-		InferenceConfig: &types.InferenceConfiguration{
-			Temperature:   aws.Float32(a.temperature),
-			TopP:          aws.Float32(a.topP),
-			MaxTokens:     aws.Int32(int32(a.maxTokens)),
-			StopSequences: a.stopSequences,
-		},
+		InferenceConfig: infConfig,
 	}
 	response, err := a.client.Converse(ctx, &converseInput)
 	if err != nil {

--- a/pkg/ai/amazonbedrockconverse_mock_test.go
+++ b/pkg/ai/amazonbedrockconverse_mock_test.go
@@ -12,9 +12,11 @@ import (
 // ---- Mock Wrapper ----
 type mockConverseClient struct {
 	converseFunc func(ctx context.Context, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error)
+	lastInput    *bedrockruntime.ConverseInput
 }
 
 func (m *mockConverseClient) Converse(ctx context.Context, input *bedrockruntime.ConverseInput, _ ...func(*bedrockruntime.Options)) (*bedrockruntime.ConverseOutput, error) {
+	m.lastInput = input
 	return m.converseFunc(ctx, input)
 }
 
@@ -240,6 +242,91 @@ func TestExtractTextFromConverseOutput(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetCompletion_ClaudeModel_UsesTemperatureOnly(t *testing.T) {
+	mock := &mockConverseClient{
+		converseFunc: func(ctx context.Context, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
+			return &bedrockruntime.ConverseOutput{
+				Output: &types.ConverseOutputMemberMessage{
+					Value: types.Message{
+						Content: []types.ContentBlock{
+							&types.ContentBlockMemberText{Value: "ok"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := &AmazonBedrockConverseClient{
+		client:      mock,
+		model:       "anthropic.claude-v2",
+		temperature: 0.5,
+		topP:        0.9,
+		maxTokens:   100,
+	}
+
+	_, err := client.GetCompletion(context.Background(), "hello")
+
+	assert.NoError(t, err)
+
+	inf := mock.lastInput.InferenceConfig
+
+	assert.NotNil(t, inf.Temperature)
+	assert.Nil(t, inf.TopP)
+}
+
+func TestGetCompletion_NonClaudeModel_UsesTemperatureAndTopP(t *testing.T) {
+	mock := &mockConverseClient{
+		converseFunc: func(ctx context.Context, input *bedrockruntime.ConverseInput) (*bedrockruntime.ConverseOutput, error) {
+			return &bedrockruntime.ConverseOutput{
+				Output: &types.ConverseOutputMemberMessage{
+					Value: types.Message{
+						Content: []types.ContentBlock{
+							&types.ContentBlockMemberText{Value: "ok"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	client := &AmazonBedrockConverseClient{
+		client:      mock,
+		model:       "amazon.titan-text",
+		temperature: 0.5,
+		topP:        0.9,
+		maxTokens:   100,
+	}
+
+	_, err := client.GetCompletion(context.Background(), "hello")
+
+	assert.NoError(t, err)
+
+	inf := mock.lastInput.InferenceConfig
+
+	assert.NotNil(t, inf.Temperature)
+	assert.NotNil(t, inf.TopP)
+	assert.Equal(t, float32(0.9), *inf.TopP)
+}
+
+func TestIsClaudeModel(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{"anthropic.claude-opus-4-6-v1", true},
+		{"CLAUDE-3", true},
+		{"amazon.titan", false},
+		{"gpt-4", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isClaudeModel(tt.model))
 		})
 	}
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
For latest Claude models on Amazon Bedrock only support Temperature OR Top P inputs. This is a stop-gap fix to support all Claude models.  A likely better fix would be to check if Temperature OR Top P is set explicitly and only pass those to the Converse API call.  If both are set by the user, pass back the AWS Error (existing functionality) as the error details that only one is allowed to be set.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->