### PR TITLE
feat: add support of gpt2giga

### DIFF
--- a/pkg/ai/gpt2giga.go
+++ b/pkg/ai/gpt2giga.go
@@ -1,0 +1,110 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	gpt2gigaClientName = "gpt2giga"
+	baseURL            = "http://localhost:8090"
+)
+
+type Gpt2GigaClient struct {
+	nopCloser
+
+	client      *http.Client
+	baseURL     string
+	model       string
+	temperature float32
+	topP        float32
+	// organizationId string
+}
+
+func (c *Gpt2GigaClient) Configure(config IAIConfig) error {
+	c.baseURL = config.GetBaseURL()
+	if c.baseURL == "" {
+		c.baseURL = baseURL
+	}
+
+	c.client = &http.Client{}
+	if proxyEndpoint := config.GetProxyEndpoint(); proxyEndpoint != "" {
+		proxyUrl, err := url.Parse(proxyEndpoint)
+		if err != nil {
+			return err
+		}
+		c.client.Transport = &http.Transport{
+			Proxy: http.ProxyURL(proxyUrl),
+		}
+	}
+
+	c.model = config.GetModel()
+	c.temperature = config.GetTemperature()
+	c.topP = config.GetTopP()
+
+	return nil
+}
+
+func (c *Gpt2GigaClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	// Making a request in the OpenAI format
+	requestBody := map[string]interface{}{
+		"model": c.model,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+		"temperature": c.temperature,
+		"top_p":       c.topP,
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+
+	if err != nil {
+		return "", fmt.Errorf("error marshaling request: %w", err)
+	}
+
+	// Sending a request
+	url := fmt.Sprintf("%s/chat/completions", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return "", fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Response processing
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var response struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return "", fmt.Errorf("error decoding response: %w", err)
+	}
+
+	if len(response.Choices) == 0 {
+		return "", errors.New("no choices in response")
+	}
+
+	return response.Choices[0].Message.Content, nil
+}
+
+func (c *Gpt2GigaClient) GetName() string {
+	return gpt2gigaClientName
+}

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -36,6 +36,7 @@ var (
 		&CustomRestClient{},
 		&IBMWatsonxAIClient{},
 		&GroqClient{},
+		&Gpt2GigaClient{},
 	}
 	Backends = []string{
 		openAIClientName,
@@ -54,6 +55,7 @@ var (
 		CustomRestClientName,
 		ibmWatsonxAIClientName,
 		groqAIClientName,
+		gpt2gigaClientName,
 	}
 )
 
@@ -193,7 +195,7 @@ func (p *AIProvider) GetCustomHeaders() []http.Header {
 	return p.CustomHeaders
 }
 
-var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "amazonbedrockconverse", "googlevertexai", "oci", "customrest"}
+var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "amazonbedrockconverse", "googlevertexai", "oci", "customrest", "gpt2giga"}
 
 func NeedPassword(backend string) bool {
 	for _, b := range passwordlessProviders {


### PR DESCRIPTION
## 📑 Description

Added support for the GPT2Giga proxy provider to integrate with the GigaChat API via OpenAI/Anthropic-compatible interfaces. Key changes include:
1. Created gpt2giga.go with the client implementation:
    - Acts as a proxy to forward requests to the GigaChat API using OpenAI format
    - Configure() method supports setting proxy endpoints and model parameters
    - GetCompletion() sends requests to the proxy endpoint and processes responses
2. Added the Gpt2GigaClient to the list of available providers in iai.go
3. Updated backend and passwordless provider lists

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->