### PR TITLE
feat: add daemonset analyzer and special cases for pod and job

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -33,6 +33,7 @@ var (
 
 var coreAnalyzerMap = map[string]common.IAnalyzer{
 	"Pod":                            PodAnalyzer{},
+	"DaemonSet":                      DaemonSetAnalyzer{},
 	"Deployment":                     DeploymentAnalyzer{},
 	"ReplicaSet":                     ReplicaSetAnalyzer{},
 	"PersistentVolumeClaim":          PvcAnalyzer{},

--- a/pkg/analyzer/daemonset.go
+++ b/pkg/analyzer/daemonset.go
@@ -1,0 +1,104 @@
+package analyzer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type DaemonSetAnalyzer struct {
+}
+
+func (DaemonSetAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
+	kind := "DaemonSet"
+	apiDoc := kubernetes.K8sApiReference{
+		Kind: kind,
+		ApiVersion: schema.GroupVersion{
+			Group:   "apps",
+			Version: "v1",
+		},
+		OpenapiSchema: a.OpenapiSchema,
+	}
+
+	AnalyzerErrorsMetric.DeletePartialMatch(map[string]string{
+		"analyzer_name": kind,
+	})
+
+	daemonsets, err := a.Client.GetClient().AppsV1().DaemonSets(a.Namespace).List(a.Context, metav1.ListOptions{LabelSelector: a.LabelSelector})
+	if err != nil {
+		return nil, err
+	}
+	var preAnalysis = map[string]common.PreAnalysis{}
+
+	for _, ds := range daemonsets.Items {
+		var failures []common.Failure
+
+		if ds.Status.NumberReady < ds.Status.DesiredNumberScheduled {
+			doc := apiDoc.GetApiDocV2("status.numberReady")
+			failures = append(failures, common.Failure{
+				Text:          fmt.Sprintf("DaemonSet %s/%s has %d ready replicas out of %d scheduled", ds.Namespace, ds.Name, ds.Status.NumberReady, ds.Status.DesiredNumberScheduled),
+				KubernetesDoc: doc,
+				Sensitive: []common.Sensitive{
+					{
+						Unmasked: ds.Namespace,
+						Masked:   util.MaskString(ds.Namespace),
+					},
+					{
+						Unmasked: ds.Name,
+						Masked:   util.MaskString(ds.Name),
+					},
+				},
+			})
+		}
+		for _, imagePullSecret := range ds.Spec.Template.Spec.ImagePullSecrets {
+			_, err := a.Client.GetClient().CoreV1().Secrets(ds.Namespace).Get(context.Background(), imagePullSecret.Name, metav1.GetOptions{})
+			if err != nil {
+				failures = append(failures, common.Failure{
+					Text: fmt.Sprintf("DaemonSet %s/%s references non-existent ImagePullSecret %s", ds.Namespace, ds.Name, imagePullSecret.Name),
+					Sensitive: []common.Sensitive{
+						{
+							Unmasked: ds.Namespace,
+							Masked:   util.MaskString(ds.Namespace),
+						},
+						{
+							Unmasked: ds.Name,
+							Masked:   util.MaskString(ds.Name),
+						},
+						{
+							Unmasked: imagePullSecret.Name,
+							Masked:   util.MaskString(imagePullSecret.Name),
+						},
+					},
+				})
+			}
+		}
+		if len(failures) > 0 {
+			preAnalysis[fmt.Sprintf("%s/%s", ds.Namespace, ds.Name)] = common.PreAnalysis{
+				FailureDetails: failures,
+				DaemonSet:      ds,
+			}
+			AnalyzerErrorsMetric.WithLabelValues(kind, ds.Name, ds.Namespace).Set(float64(len(failures)))
+		}
+	}
+
+	for key, value := range preAnalysis {
+		var currentAnalysis = common.Result{
+			Kind:  kind,
+			Name:  key,
+			Error: value.FailureDetails,
+		}
+
+		parent, found := util.GetParent(a.Client, value.DaemonSet.ObjectMeta)
+		if found {
+			currentAnalysis.ParentObject = parent
+		}
+		a.Results = append(a.Results, currentAnalysis)
+	}
+
+	return a.Results, nil
+}

--- a/pkg/analyzer/daemonset_test.go
+++ b/pkg/analyzer/daemonset_test.go
@@ -1,0 +1,163 @@
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/magiconair/properties/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestDaemonSetAnalyzer(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "example-container",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 1,
+			NumberReady:            1,
+		},
+	})
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	daemonSetAnalyzer := DaemonSetAnalyzer{}
+	analysisResults, err := daemonSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
+}
+
+func TestDaemonSetAnalyzerNoReadyReplicas(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "example-container",
+							Image: "nginx",
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 80,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 3,
+			NumberReady:            2,
+		},
+	})
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	daemonSetAnalyzer := DaemonSetAnalyzer{}
+	analysisResults, err := daemonSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+	assert.Equal(t, analysisResults[0].Kind, "DaemonSet")
+	assert.Equal(t, analysisResults[0].Name, "default/example")
+}
+
+func TestDaemonSetAnalyzerImagePullSecretNotFound(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "example",
+			Namespace: "default",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"key": "value",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					ImagePullSecrets: []v1.LocalObjectReference{
+						{
+							Name: "non-existent-secret",
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "example-container",
+							Image: "nginx",
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.DaemonSetStatus{
+			DesiredNumberScheduled: 1,
+			NumberReady:            1,
+		},
+	})
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	daemonSetAnalyzer := DaemonSetAnalyzer{}
+	analysisResults, err := daemonSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+	assert.Equal(t, analysisResults[0].Kind, "DaemonSet")
+	assert.Equal(t, analysisResults[0].Name, "default/example")
+}

--- a/pkg/analyzer/job.go
+++ b/pkg/analyzer/job.go
@@ -70,7 +70,8 @@ func (analyzer JobAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 		}
 		if Job.Status.Failed > 0 {
 			doc := apiDoc.GetApiDocV2("status.failed")
-			failures = append(failures, common.Failure{
+
+			failure := common.Failure{
 				Text:          fmt.Sprintf("Job %s has failed", Job.Name),
 				KubernetesDoc: doc,
 				Sensitive: []common.Sensitive{
@@ -83,7 +84,16 @@ func (analyzer JobAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 						Masked:   util.MaskString(Job.Name),
 					},
 				},
-			})
+			}
+
+			evt, err := util.FetchLatestEvent(a.Context, a.Client, Job.Namespace, Job.Name)
+
+			// Check for Event BackoffLimitExceeded
+			if evt != nil && err == nil && evt.Reason == "BackoffLimitExceeded" && evt.Message != "" {
+				failure.Text = evt.Message
+			}
+
+			failures = append(failures, failure)
 		}
 
 		if len(failures) > 0 {

--- a/pkg/analyzer/job_test.go
+++ b/pkg/analyzer/job_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -169,6 +170,56 @@ func TestJobAnalyzer(t *testing.T) {
 				require.Equal(t, expectation.name, results[i].Name)
 				require.Len(t, results[i].Error, expectation.failuresCount)
 			}
+		})
+	}
+}
+
+func TestJobAnalyzerEventFailure(t *testing.T) {
+	tests := map[string]struct {
+		config       common.Analyzer
+		expectedText string
+	}{
+		"Failed Job with BackoffLimitExceeded Event": {
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&batchv1.Job{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "backoff-job",
+								Namespace: "default",
+							},
+							Spec: batchv1.JobSpec{},
+							Status: batchv1.JobStatus{
+								Failed: 1,
+							},
+						},
+						&corev1.Event{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "backoff-event",
+								Namespace: "default",
+							},
+							Reason:  "BackoffLimitExceeded",
+							Message: "Job has reached the specified backoff limit",
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			expectedText: "Job has reached the specified backoff limit",
+		},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			analyzer := JobAnalyzer{}
+			results, err := analyzer.Analyze(tt.config)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Equal(t, "default/backoff-job", results[0].Name)
+			require.Len(t, results[0].Error, 1)
+
+			require.Contains(t, results[0].Error[0].Text, tt.expectedText)
 		})
 	}
 }

--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -60,6 +60,20 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			}
 		}
 
+		// Check for evicted pods
+		if pod.Status.Reason == "Evicted" {
+			failure := common.Failure{
+				Text:      fmt.Sprintf("Pod %s has been evicted", pod.Name),
+				Sensitive: []common.Sensitive{},
+			}
+
+			if pod.Status.Message != "" {
+				failure.Text = pod.Status.Message
+			}
+
+			failures = append(failures, failure)
+		}
+
 		// Check for errors in the init containers.
 		failures = append(failures, analyzeContainerStatusFailures(a, pod.Status.InitContainerStatuses, pod.Name, pod.Namespace, string(pod.Status.Phase))...)
 

--- a/pkg/analyzer/pod_test.go
+++ b/pkg/analyzer/pod_test.go
@@ -120,6 +120,66 @@ func TestPodAnalyzer(t *testing.T) {
 			},
 		},
 		{
+			name: "Evicted pod with message",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "EvictedPod",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Reason:  "Evicted",
+								Message: "Pod was rejected: The node had condition: [DiskPressure]. ",
+							},
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			expectations: []struct {
+				name          string
+				failuresCount int
+			}{
+				{
+					name:          "default/EvictedPod",
+					failuresCount: 1,
+				},
+			},
+		},
+		{
+			name: "Evicted pod without message",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "EvictedPod",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Reason:  "Evicted",
+								Message: "",
+							},
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			expectations: []struct {
+				name          string
+				failuresCount int
+			}{
+				{
+					name:          "default/EvictedPod",
+					failuresCount: 1,
+				},
+			},
+		},
+		{
 			name: "readiness probe failure without any event",
 			config: common.Analyzer{
 				Client: &kubernetes.Client{

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -50,6 +50,7 @@ type Analyzer struct {
 type PreAnalysis struct {
 	Pod                      v1.Pod
 	FailureDetails           []Failure
+	DaemonSet                appsv1.DaemonSet
 	Deployment               appsv1.Deployment
 	ReplicaSet               appsv1.ReplicaSet
 	PersistentVolumeClaim    v1.PersistentVolumeClaim


### PR DESCRIPTION
## 📑 Description
The current responses have been analyzed and the following cases have been added:
- Analyzer for DaemonSet. It compares the number of replicas and checks the existence of all ImagePullSecrets
- Checking the BackoffLimitExceeded event for Job
- Handling the Evicted state for Pod

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
**Analysis results:**
0: DaemonSet default/test-daemonset-invalid-secret()
* Error: DaemonSet default/test-daemonset-invalid-secret has 0 ready replicas out of 2 scheduled
* Error: DaemonSet default/test-daemonset-invalid-secret references non-existent ImagePullSecret non-existent-secret

0: Pod evicted-test/evicted-test-pod()
* Error: Pod was rejected: The node had condition: \[DiskPressure\].

3: Job job-stuck-test/failing-job()
* Error: Job has reached the specified backoff limit