### PR TITLE
feat: addition of an optional flag (azureAPIType) to support the AzureOpenAI backend

### DIFF
--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+	"github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -66,11 +67,21 @@ var addCmd = &cobra.Command{
 			return false
 		}
 
-		// check if backend is not empty and a valid value
-		if backend == "" {
+		switch backend {
+		case "": // check if backend is not empty and a valid value
 			color.Yellow(fmt.Sprintf("Warning: backend input is empty, will use the default value: %s", defaultBackend))
 			backend = defaultBackend
-		} else {
+		case "azureopenai":
+			azureAPIType, _ := cmd.Flags().GetString("azureAPIType")
+
+			switch openai.APIType(azureAPIType) {
+			case "", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure:
+				// valid types
+			default:
+				color.Red("Error: Valid values of azureAPIType for azureopenai backends are AZURE, AZURE_AD or CLOUDFLARE_AZURE")
+				os.Exit(1)
+			}
+		default:
 			if !validBackend(ai.Backends, backend) {
 				color.Red("Error: Backend AI accepted values are '%v'", strings.Join(ai.Backends, ", "))
 				os.Exit(1)
@@ -145,6 +156,7 @@ var addCmd = &cobra.Command{
 			MaxTokens:      maxTokens,
 			StopSequences:  stopSequences,
 			OrganizationId: organizationId,
+			AzureAPIType:   azureAPIType,
 		}
 
 		if providerIndex == -1 {
@@ -191,4 +203,6 @@ func init() {
 	addCmd.Flags().StringVarP(&compartmentId, "compartmentId", "k", "", "Compartment ID for generative AI model (only for oci backend)")
 	// add flag for openai organization
 	addCmd.Flags().StringVarP(&organizationId, "organizationId", "o", "", "OpenAI or AzureOpenAI Organization ID (only for openai and azureopenai backend)")
+	// add flag for azure open ai APIType name
+	addCmd.Flags().StringVarP(&azureAPIType, "azureAPIType", "a", "", fmt.Sprintf("AzureOpenAI API Type name. Valid values: %s, %s or %s (only for azureopenai backend)", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure))
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -34,6 +34,7 @@ var (
 	maxTokens      int
 	stopSequences  []string
 	organizationId string
+	azureAPIType   string
 )
 
 var configAI ai.AIConfiguration

--- a/cmd/auth/update.go
+++ b/cmd/auth/update.go
@@ -14,10 +14,12 @@ limitations under the License.
 package auth
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/sashabaranov/go-openai"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -33,6 +35,16 @@ var updateCmd = &cobra.Command{
 		if strings.ToLower(backend) == "azureopenai" {
 			_ = cmd.MarkFlagRequired("engine")
 			_ = cmd.MarkFlagRequired("baseurl")
+
+			azureAPIType, _ := cmd.Flags().GetString("azureAPIType")
+
+			switch openai.APIType(azureAPIType) {
+			case "", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure:
+				// valid types
+			default:
+				color.Red("Error: Valid values of azureAPIType for azureopenai backends are AZURE, AZURE_AD or CLOUDFLARE_AZURE")
+				os.Exit(1)
+			}
 		}
 		organizationId, _ := cmd.Flags().GetString("organizationId")
 		if strings.ToLower(backend) != "azureopenai" && strings.ToLower(backend) != "openai" {
@@ -85,6 +97,10 @@ var updateCmd = &cobra.Command{
 					configAI.Providers[i].OrganizationId = organizationId
 					color.Blue("Organization Id updated successfully")
 				}
+				if azureAPIType != "" {
+					configAI.Providers[i].AzureAPIType = azureAPIType
+					color.Blue("AzureAPIType updated successfully")
+				}
 				configAI.Providers[i].Temperature = temperature
 				color.Green("%s updated in the AI backend provider list", backend)
 			}
@@ -117,4 +133,6 @@ func init() {
 	updateCmd.Flags().StringVarP(&engine, "engine", "e", "", "Update Azure AI deployment name")
 	// update flag for organizationId
 	updateCmd.Flags().StringVarP(&organizationId, "organizationId", "o", "", "Update OpenAI or Azure organization Id")
+	// add flag for azure open ai APIType name
+	updateCmd.Flags().StringVarP(&azureAPIType, "azureAPIType", "a", "", fmt.Sprintf("AzureOpenAI API Type name. Valid values: %s, %s or %s (only for azureopenai backend)", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure))
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -14,8 +14,10 @@ limitations under the License.
 package serve
 
 import (
+	"net/http"
 	"os"
 	"strconv"
+	"strings"
 
 	k8sgptserver "github.com/k8sgpt-ai/k8sgpt/pkg/server"
 
@@ -120,12 +122,31 @@ var ServeCmd = &cobra.Command{
 				}
 				return int(maxTokens)
 			}
+
+			// Parse custom headers from environment variable
+			parseCustomHeaders := func() []http.Header {
+				headersEnv := os.Getenv("K8SGPT_CUSTOM_HEADERS")
+				if headersEnv == "" {
+					return nil
+				}
+
+				header := make(http.Header)
+				headerPairs := strings.Split(headersEnv, ",")
+				for _, pair := range headerPairs {
+					kv := strings.SplitN(pair, ":", 2)
+					if len(kv) == 2 {
+						header.Add(strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1]))
+					}
+				}
+				return []http.Header{header}
+			}
 			// Check for env injection
 			backend = os.Getenv("K8SGPT_BACKEND")
 			password := os.Getenv("K8SGPT_PASSWORD")
 			model := os.Getenv("K8SGPT_MODEL")
 			baseURL := os.Getenv("K8SGPT_BASEURL")
 			engine := os.Getenv("K8SGPT_ENGINE")
+			azureAPIType := os.Getenv("K8SGPT_AZURE_API_TYPE")
 			proxyEndpoint := os.Getenv("K8SGPT_PROXY_ENDPOINT")
 			providerId := os.Getenv("K8SGPT_PROVIDER_ID")
 			// If the envs are set, allocate in place to the aiProvider
@@ -138,6 +159,8 @@ var ServeCmd = &cobra.Command{
 					Model:         model,
 					BaseURL:       baseURL,
 					Engine:        engine,
+					AzureAPIType:  azureAPIType,
+					CustomHeaders: parseCustomHeaders(),
 					ProxyEndpoint: proxyEndpoint,
 					ProviderId:    providerId,
 					Temperature:   temperature(),

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -20,6 +21,22 @@ type AzureAIClient struct {
 	// organizationId string
 }
 
+type customHeaderRoundTripper struct {
+	headers []http.Header
+	rt      http.RoundTripper
+}
+
+func (c *customHeaderRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	for _, header := range c.headers {
+		for key, values := range header {
+			for _, value := range values {
+				req.Header.Add(key, value)
+			}
+		}
+	}
+	return c.rt.RoundTrip(req)
+}
+
 func (c *AzureAIClient) Configure(config IAIConfig) error {
 	token := config.GetPassword()
 	baseURL := config.GetBaseURL()
@@ -27,6 +44,7 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 	proxyEndpoint := config.GetProxyEndpoint()
 	defaultConfig := openai.DefaultAzureConfig(token, baseURL)
 	orgId := config.GetOrganizationId()
+	azureAPIType := config.GetAzureAPIType()
 
 	defaultConfig.AzureModelMapperFunc = func(model string) string {
 		// If you use a deployment name different from the model name, you can customize the AzureModelMapperFunc function
@@ -37,7 +55,20 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 
 	}
 
-	if proxyEndpoint != "" {
+	customHeaders := config.GetCustomHeaders()
+	fmt.Println("azureopenai.go Custom Headers:", customHeaders)
+	if len(customHeaders) > 0 {
+		fmt.Println("azureopenai.go ( customHeaders > 0 ) Custom Headers:", customHeaders)
+		transport := &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+		}
+		defaultConfig.HTTPClient = &http.Client{
+			Transport: &customHeaderRoundTripper{
+				headers: customHeaders,
+				rt:      transport,
+			},
+		}
+	} else if proxyEndpoint != "" {
 		proxyUrl, err := url.Parse(proxyEndpoint)
 		if err != nil {
 			return err
@@ -52,6 +83,15 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 	}
 	if orgId != "" {
 		defaultConfig.OrgID = orgId
+	}
+
+	switch azureAPIType {
+	case string(openai.APITypeAzure):
+		defaultConfig.APIType = openai.APITypeAzure
+	case string(openai.APITypeAzureAD):
+		defaultConfig.APIType = openai.APITypeAzureAD
+	case string(openai.APITypeCloudflareAzure):
+		defaultConfig.APIType = openai.APITypeCloudflareAzure
 	}
 
 	client := openai.NewClientWithConfig(defaultConfig)

--- a/pkg/ai/azureopenai_test.go
+++ b/pkg/ai/azureopenai_test.go
@@ -1,0 +1,301 @@
+package ai
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// azureMockConfig implements IAIConfig for Azure OpenAI tests.
+type azureMockConfig struct {
+	baseURL       string
+	azureAPIType  string
+	customHeaders []http.Header
+	engine        string
+	proxyEndpoint string
+	organizationId string
+}
+
+func (m *azureMockConfig) GetPassword() string        { return "test-token" }
+func (m *azureMockConfig) GetModel() string            { return "gpt-4" }
+func (m *azureMockConfig) GetBaseURL() string          { return m.baseURL }
+func (m *azureMockConfig) GetProxyEndpoint() string    { return m.proxyEndpoint }
+func (m *azureMockConfig) GetEndpointName() string     { return "" }
+func (m *azureMockConfig) GetEngine() string           { return m.engine }
+func (m *azureMockConfig) GetTemperature() float32     { return 0.0 }
+func (m *azureMockConfig) GetProviderRegion() string   { return "" }
+func (m *azureMockConfig) GetTopP() float32            { return 0.0 }
+func (m *azureMockConfig) GetTopK() int32              { return 0 }
+func (m *azureMockConfig) GetMaxTokens() int           { return 0 }
+func (m *azureMockConfig) GetStopSequences() []string  { return nil }
+func (m *azureMockConfig) GetProviderId() string       { return "" }
+func (m *azureMockConfig) GetCompartmentId() string    { return "" }
+func (m *azureMockConfig) GetOrganizationId() string   { return m.organizationId }
+func (m *azureMockConfig) GetAzureAPIType() string     { return m.azureAPIType }
+func (m *azureMockConfig) GetCustomHeaders() []http.Header { return m.customHeaders }
+
+// ---------------------------------------------------------------------------
+// customHeaderRoundTripper tests
+// ---------------------------------------------------------------------------
+
+func TestCustomHeaderRoundTripper_InjectsHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt := &customHeaderRoundTripper{
+		headers: []http.Header{
+			{"X-Custom-One": []string{"ValueA"}},
+		},
+		rt: http.DefaultTransport,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "ValueA", receivedHeaders.Get("X-Custom-One"))
+}
+
+func TestCustomHeaderRoundTripper_MultipleHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt := &customHeaderRoundTripper{
+		headers: []http.Header{
+			{"X-First": []string{"1"}},
+			{"X-Second": []string{"2a", "2b"}},
+		},
+		rt: http.DefaultTransport,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "1", receivedHeaders.Get("X-First"))
+	assert.ElementsMatch(t, []string{"2a", "2b"}, receivedHeaders.Values("X-Second"))
+}
+
+func TestCustomHeaderRoundTripper_PreservesExistingHeaders(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	rt := &customHeaderRoundTripper{
+		headers: []http.Header{
+			{"X-Injected": []string{"injected-value"}},
+		},
+		rt: http.DefaultTransport,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Existing", "existing-value")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, "existing-value", receivedHeaders.Get("X-Existing"))
+	assert.Equal(t, "injected-value", receivedHeaders.Get("X-Injected"))
+}
+
+// ---------------------------------------------------------------------------
+// AzureAIClient.Configure() tests
+// ---------------------------------------------------------------------------
+
+func TestAzureAIClient_Configure_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL: server.URL,
+		engine:  "gpt-4",
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	assert.NoError(t, err)
+	assert.Equal(t, "gpt-4", client.model)
+}
+
+func TestAzureAIClient_Configure_APIType(t *testing.T) {
+	tests := []struct {
+		name         string
+		azureAPIType string
+	}{
+		{"empty string keeps default", ""},
+		{"AZURE type", "AZURE"},
+		{"AZURE_AD type", "AZURE_AD"},
+		{"CLOUDFLARE_AZURE type", "CLOUDFLARE_AZURE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			config := &azureMockConfig{
+				baseURL:      server.URL,
+				engine:       "gpt-4",
+				azureAPIType: tt.azureAPIType,
+			}
+
+			client := &AzureAIClient{}
+			err := client.Configure(config)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestAzureAIClient_Configure_CustomHeaders(t *testing.T) {
+	headerReceived := make(chan http.Header, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		headerReceived <- r.Header
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"content": "test response"}}]}`))
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL: server.URL,
+		engine:  "gpt-4",
+		customHeaders: []http.Header{
+			{"X-Custom-Auth": []string{"bearer-token-123"}},
+			{"X-Request-Source": []string{"k8sgpt"}},
+		},
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	require.NoError(t, err)
+
+	_, _ = client.GetCompletion(context.Background(), "test prompt")
+
+	received := <-headerReceived
+	assert.Equal(t, "bearer-token-123", received.Get("X-Custom-Auth"))
+	assert.Equal(t, "k8sgpt", received.Get("X-Request-Source"))
+}
+
+func TestAzureAIClient_Configure_NoCustomHeaders_NoProxy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL: server.URL,
+		engine:  "gpt-4",
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	assert.NoError(t, err)
+}
+
+func TestAzureAIClient_Configure_WithOrganizationId(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL:        server.URL,
+		engine:         "gpt-4",
+		organizationId: "org-12345",
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	assert.NoError(t, err)
+}
+
+// ---------------------------------------------------------------------------
+// AzureAIClient.GetCompletion() end-to-end tests
+// ---------------------------------------------------------------------------
+
+func TestAzureAIClient_GetCompletion_WithCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify custom headers are present
+		assert.Equal(t, "Value1", r.Header.Get("X-Custom-Header-1"))
+		assert.ElementsMatch(t, []string{"Value2", "Value3"}, r.Header.Values("X-Custom-Header-2"))
+
+		w.WriteHeader(http.StatusOK)
+		mockResponse := `{"choices": [{"message": {"content": "azure test response"}}]}`
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL: server.URL,
+		engine:  "gpt-4",
+		customHeaders: []http.Header{
+			{"X-Custom-Header-1": []string{"Value1"}},
+			{"X-Custom-Header-2": []string{"Value2", "Value3"}},
+		},
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	require.NoError(t, err)
+
+	result, err := client.GetCompletion(context.Background(), "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "azure test response", result)
+}
+
+func TestAzureAIClient_GetCompletion_WithoutCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		mockResponse := `{"choices": [{"message": {"content": "plain response"}}]}`
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL: server.URL,
+		engine:  "gpt-4",
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	require.NoError(t, err)
+
+	result, err := client.GetCompletion(context.Background(), "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "plain response", result)
+}
+
+func TestAzureAIClient_GetName(t *testing.T) {
+	client := &AzureAIClient{}
+	assert.Equal(t, "azureopenai", client.GetName())
+}

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -91,6 +91,7 @@ type IAIConfig interface {
 	GetProviderId() string
 	GetCompartmentId() string
 	GetOrganizationId() string
+	GetAzureAPIType() string
 	GetCustomHeaders() []http.Header
 }
 
@@ -127,6 +128,7 @@ type AIProvider struct {
 	MaxTokens      int           `mapstructure:"maxtokens" yaml:"maxtokens,omitempty"`
 	StopSequences  []string      `mapstructure:"stopsequences" yaml:"stopsequences,omitempty"`
 	OrganizationId string        `mapstructure:"organizationid" yaml:"organizationid,omitempty"`
+	AzureAPIType   string        `mapstructure:"azureapitype" yaml:"azureapitype,omitempty"`
 	CustomHeaders  []http.Header `mapstructure:"customHeaders"`
 }
 
@@ -187,6 +189,10 @@ func (p *AIProvider) GetCompartmentId() string {
 
 func (p *AIProvider) GetOrganizationId() string {
 	return p.OrganizationId
+}
+
+func (p *AIProvider) GetAzureAPIType() string {
+	return p.AzureAPIType
 }
 
 func (p *AIProvider) GetCustomHeaders() []http.Header {

--- a/pkg/ai/openai_header_transport_test.go
+++ b/pkg/ai/openai_header_transport_test.go
@@ -80,6 +80,10 @@ func (m *mockConfig) GetProviderRegion() string {
 	return ""
 }
 
+func (m *mockConfig) GetAzureAPIType() string {
+	return ""
+}
+
 func TestOpenAIClient_CustomHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Value1", r.Header.Get("X-Custom-Header-1"))

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -203,7 +203,24 @@ func NewAnalysis(
 	}
 
 	aiClient := ai.NewClient(aiProvider.Name)
-	customHeaders := util.NewHeaders(httpHeaders)
+
+	var headerStrings []string
+
+	// If AI provider has custom headers in config, use those first
+	if len(aiProvider.CustomHeaders) > 0 {
+		for _, header := range aiProvider.CustomHeaders {
+			for key, values := range header {
+				for _, value := range values {
+					headerStrings = append(headerStrings, fmt.Sprintf("%s:%s", key, value))
+				}
+			}
+		}
+	} else if len(httpHeaders) > 0 {
+		headerStrings = httpHeaders
+	}
+
+	customHeaders := util.NewHeaders(headerStrings)
+
 	aiProvider.CustomHeaders = customHeaders
 	if verbose {
 		fmt.Println("Debug: Checking AI client initialization.")


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1247 <!-- Issue # 1247-->

## 📑 Description
Azure API Type Support
Allows users to specify an Azure OpenAI API type (AZURE, AZURE_AD, or CLOUDFLARE_AZURE) when authenticating with the azureopenai backend.

Custom HTTP Header Injection

Allows injecting custom HTTP headers into Azure OpenAI API requests, either via provider config or the K8SGPT_CUSTOM_HEADERS environment variable.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->