### PR TITLE
fix(analyzer): skip succeeded pods to prevent false positive reports

### DIFF
--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -45,6 +45,14 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	for _, pod := range list.Items {
 		var failures []common.Failure
 
+		// Skip pods that have successfully completed (e.g., Job/CronJob pods).
+		// A Succeeded pod has finished its work normally; sidecar containers may
+		// be terminated with non-zero exit codes when the pod shuts down, which
+		// should not be treated as failures.
+		if pod.Status.Phase == v1.PodSucceeded {
+			continue
+		}
+
 		// Check for pending pods
 		if pod.Status.Phase == "Pending" {
 			// Check through container status to check for crashes

--- a/pkg/analyzer/pod_test.go
+++ b/pkg/analyzer/pod_test.go
@@ -344,6 +344,51 @@ func TestPodAnalyzer(t *testing.T) {
 			},
 		},
 		{
+			name: "Succeeded pod with non-zero exit code container should not be reported",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "Pod1",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								// Completed Job pod: phase is Succeeded even if a sidecar
+								// container exited with a non-zero code on shutdown.
+								Phase: v1.PodSucceeded,
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										Name:  "main",
+										Ready: false,
+										State: v1.ContainerState{
+											Terminated: &v1.ContainerStateTerminated{
+												ExitCode: 0,
+												Reason:   "Completed",
+											},
+										},
+									},
+									{
+										Name:  "sidecar",
+										Ready: false,
+										State: v1.ContainerState{
+											Terminated: &v1.ContainerStateTerminated{
+												ExitCode: 255,
+												Reason:   "Error",
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			// No failures expected: the pod completed successfully.
+		},
+		{
 			name: "Terminated container with non-zero exit code",
 			config: common.Analyzer{
 				Client: &kubernetes.Client{


### PR DESCRIPTION
Fixes #1581

## Problem

The pod analyzer incorrectly reports completed Job/CronJob pods as having issues. When a multi-container pod finishes successfully, sidecar containers are terminated by Kubernetes with non-zero exit codes (commonly 255). The analyzer was flagging these terminated sidecar containers as failures even though the pod phase was `Succeeded` (shown as `Completed` by kubectl).

Example false positive:
```
2. xxx/smoke-test-xxx-cloudloader-dataeditor-2-f7rl4
   Type: Pod
   Error 1: the termination reason is Error exitCode=255 container=smoke-test ...
```

## Solution

Add an early-continue guard at the top of the pod analysis loop that skips any pod whose phase is `PodSucceeded`. A pod in this phase has completed its work normally; there is no value in analyzing its container states for failures.

```go
if pod.Status.Phase == v1.PodSucceeded {
    continue
}
```

## Testing

Added a test case `"Succeeded pod with non-zero exit code container should not be reported"` that creates a pod in `PodSucceeded` phase with a sidecar container terminated with exit code 255, and asserts that no failures are reported.