### PR TITLE
feat: analyze previous logs for restarted containers

### DIFF
--- a/pkg/analyzer/log.go
+++ b/pkg/analyzer/log.go
@@ -49,37 +49,11 @@ func (LogAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	// Iterate through each pod
 
 	for _, pod := range list.Items {
-		podName := pod.Name
 		for _, c := range pod.Spec.Containers {
 			var failures []common.Failure
-			podLogOptions := v1.PodLogOptions{
-				TailLines: &tailLines,
-				Container: c.Name,
-			}
-			podLogs, err := a.Client.Client.CoreV1().Pods(pod.Namespace).GetLogs(podName, &podLogOptions).DoRaw(a.Context)
-			if err != nil {
-				failures = append(failures, common.Failure{
-					Text: fmt.Sprintf("Error %s from Pod %s", err.Error(), pod.Name),
-					Sensitive: []common.Sensitive{
-						{
-							Unmasked: pod.Name,
-							Masked:   util.MaskString(pod.Name),
-						},
-					},
-				})
-			} else {
-				rawlogs := string(podLogs)
-				if errorPattern.MatchString(strings.ToLower(rawlogs)) {
-					failures = append(failures, common.Failure{
-						Text: printErrorLines(rawlogs, errorPattern),
-						Sensitive: []common.Sensitive{
-							{
-								Unmasked: pod.Name,
-								Masked:   util.MaskString(pod.Name),
-							},
-						},
-					})
-				}
+			failures = append(failures, analyzeLogs(a, pod, c.Name, false, true)...)
+			if containerHasRestarted(pod.Status.ContainerStatuses, c.Name) {
+				failures = append(failures, analyzeLogs(a, pod, c.Name, true, false)...)
 			}
 			if len(failures) > 0 {
 				preAnalysis[fmt.Sprintf("%s/%s/%s", pod.Namespace, pod.Name, c.Name)] = common.PreAnalysis{
@@ -105,6 +79,62 @@ func (LogAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 
 	return a.Results, nil
 }
+
+func analyzeLogs(a common.Analyzer, pod v1.Pod, containerName string, previous bool, reportLogErrors bool) []common.Failure {
+	podLogOptions := v1.PodLogOptions{
+		TailLines: &tailLines,
+		Container: containerName,
+		Previous:  previous,
+	}
+	podLogs, err := a.Client.Client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOptions).DoRaw(a.Context)
+	if err != nil {
+		if !reportLogErrors {
+			return nil
+		}
+		return []common.Failure{
+			{
+				Text: fmt.Sprintf("Error %s from Pod %s", err.Error(), pod.Name),
+				Sensitive: []common.Sensitive{
+					{
+						Unmasked: pod.Name,
+						Masked:   util.MaskString(pod.Name),
+					},
+				},
+			},
+		}
+	}
+
+	rawlogs := string(podLogs)
+	if !errorPattern.MatchString(strings.ToLower(rawlogs)) {
+		return nil
+	}
+
+	failureText := printErrorLines(rawlogs, errorPattern)
+	if previous {
+		failureText = fmt.Sprintf("previous container logs: %s", failureText)
+	}
+	return []common.Failure{
+		{
+			Text: failureText,
+			Sensitive: []common.Sensitive{
+				{
+					Unmasked: pod.Name,
+					Masked:   util.MaskString(pod.Name),
+				},
+			},
+		},
+	}
+}
+
+func containerHasRestarted(statuses []v1.ContainerStatus, containerName string) bool {
+	for _, status := range statuses {
+		if status.Name == containerName && status.RestartCount > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func printErrorLines(logs string, errorPattern *regexp.Regexp) string {
 	// Split the logs into lines
 	logLines := strings.Split(logs, "\n")

--- a/pkg/analyzer/log_test.go
+++ b/pkg/analyzer/log_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 func TestLogAnalyzer(t *testing.T) {
@@ -170,4 +171,73 @@ func TestLogAnalyzerLabelSelectorFiltering(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(results))
 	require.Equal(t, "default/Pod1/test-container1", results[0].Name)
+}
+
+func TestLogAnalyzerReadsPreviousLogsForRestartedContainers(t *testing.T) {
+	oldPattern := errorPattern
+	errorPattern = regexp.MustCompile(`(fake logs)`)
+	t.Cleanup(func() {
+		errorPattern = oldPattern
+	})
+
+	clientSet := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "restarted-pod",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "app",
+					},
+				},
+			},
+			Status: v1.PodStatus{
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:         "app",
+						RestartCount: 1,
+					},
+				},
+			},
+		},
+	)
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientSet,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	logAnalyzer := LogAnalyzer{}
+	results, err := logAnalyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, "default/restarted-pod/app", results[0].Name)
+	require.Len(t, results[0].Error, 2)
+	require.Equal(t, "fake logs", results[0].Error[0].Text)
+	require.Equal(t, "previous container logs: fake logs", results[0].Error[1].Text)
+
+	var currentLogRequests int
+	var previousLogRequests int
+	for _, action := range clientSet.Actions() {
+		if !action.Matches("get", "pods") || action.GetSubresource() != "log" {
+			continue
+		}
+		genericAction, ok := action.(clienttesting.GenericAction)
+		require.True(t, ok)
+		logOptions, ok := genericAction.GetValue().(*v1.PodLogOptions)
+		require.True(t, ok)
+		if logOptions.Previous {
+			previousLogRequests++
+		} else {
+			currentLogRequests++
+		}
+	}
+
+	require.Equal(t, 1, currentLogRequests)
+	require.Equal(t, 1, previousLogRequests)
 }


### PR DESCRIPTION
Closes #1370

## 📑 Description
This PR updates the Log analyzer to inspect previous container logs when Kubernetes reports that a container has restarted. Current logs are analyzed as before; previous logs are fetched only for containers with `RestartCount > 0`, and matching findings are labeled as previous container logs so the source is clear.

The optional previous-log fetch does not create a new analyzer failure if Kubernetes no longer has the previous log stream available. A regression test verifies that restarted containers request logs with `PodLogOptions.Previous = true`.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
Validated with:
- `go test ./pkg/analyzer -run 'TestLogAnalyzer'`\n- `go test ./pkg/analyzer`\n- `go test ./...`\n- `go vet ./pkg/analyzer`