### PR TITLE
fix: skip empty ingress tls secret names

### DIFF
--- a/pkg/analyzer/ingress.go
+++ b/pkg/analyzer/ingress.go
@@ -129,6 +129,9 @@ func (IngressAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 		}
 
 		for _, tls := range ing.Spec.TLS {
+			if tls.SecretName == "" {
+				continue
+			}
 			_, err := a.Client.GetClient().CoreV1().Secrets(ing.Namespace).Get(a.Context, tls.SecretName, metav1.GetOptions{})
 			if err != nil {
 				doc := apiDoc.GetApiDocV2("spec.tls.secretName")

--- a/pkg/analyzer/ingress_test.go
+++ b/pkg/analyzer/ingress_test.go
@@ -247,6 +247,39 @@ func TestIngressAnalyzerLabelSelector(t *testing.T) {
 	require.Equal(t, "default/ingress-with-label", results[0].Name)
 }
 
+func TestIngressAnalyzerSkipsEmptyTLSSecretName(t *testing.T) {
+	ingressClassName := "gce"
+	clientSet := fake.NewSimpleClientset(
+		&networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default-certificate-ingress",
+				Namespace: "default",
+			},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: &ingressClassName,
+				TLS: []networkingv1.IngressTLS{
+					{
+						Hosts: []string{"example.com"},
+					},
+				},
+			},
+		},
+	)
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientSet,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := IngressAnalyzer{}
+	results, err := analyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Empty(t, results)
+}
+
 func TestIsGKEBuiltInIngressClass(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Closes #1075

## 📑 Description
This PR updates the Ingress analyzer to treat empty `spec.tls[].secretName` values as intentionally unset. Kubernetes allows an Ingress TLS entry to omit `secretName` and rely on the ingress controller default certificate, so k8sgpt should only validate TLS secrets when a secret name is present.

A regression test covers an Ingress with TLS hosts and no `secretName`.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
Validated with:
- `go test ./pkg/analyzer -run 'TestIngressAnalyzer|TestIsGKE'`\n- `go test ./pkg/analyzer`\n- `go test ./...`\n- `go vet ./pkg/analyzer`