### PR TITLE
fix: allow Azure OpenAI API version override

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -11,6 +11,8 @@ K8sGPT supports a variety of AI/LLM providers (backends). Some providers have a 
 
 ### Azure OpenAI
 - **Model:** User-configurable (any model deployed in your Azure OpenAI resource)
+- **Deployment:** Use `--engine` to set the Azure deployment name when it differs from the model name.
+- **API version:** Use `--azureAPIVersion` or `K8SGPT_AZURE_API_VERSION` to override the Azure OpenAI API version.
 
 ### LocalAI
 - **Model:** User-configurable (default: `llama3`)

--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -146,24 +146,7 @@ var addCmd = &cobra.Command{
 		}
 
 		// create new provider object
-		newProvider := ai.AIProvider{
-			Name:           backend,
-			Model:          model,
-			Password:       password,
-			BaseURL:        baseURL,
-			EndpointName:   endpointName,
-			Engine:         engine,
-			Temperature:    temperature,
-			ProviderRegion: providerRegion,
-			ProviderId:     providerId,
-			CompartmentId:  compartmentId,
-			TopP:           topP,
-			TopK:           topK,
-			MaxTokens:      maxTokens,
-			StopSequences:  stopSequences,
-			OrganizationId: organizationId,
-			AzureAPIType:   azureAPIType,
-		}
+		newProvider := newAIProviderFromAuthFlags(backend)
 
 		if providerIndex == -1 {
 			// provider with same name does not exist, add new provider to list
@@ -211,4 +194,6 @@ func init() {
 	addCmd.Flags().StringVarP(&organizationId, "organizationId", "o", "", "OpenAI or AzureOpenAI Organization ID (only for openai and azureopenai backend)")
 	// add flag for azure open ai APIType name
 	addCmd.Flags().StringVarP(&azureAPIType, "azureAPIType", "a", "", fmt.Sprintf("AzureOpenAI API Type name. Valid values: %s, %s or %s (only for azureopenai backend)", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure))
+	// add flag for azure open ai API version
+	addCmd.Flags().StringVarP(&azureAPIVersion, "azureAPIVersion", "", "", "AzureOpenAI API version, e.g. 2024-02-15-preview (only for azureopenai backend)")
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -19,22 +19,23 @@ import (
 )
 
 var (
-	backend        string
-	password       string
-	baseURL        string
-	endpointName   string
-	model          string
-	engine         string
-	temperature    float32
-	providerRegion string
-	providerId     string
-	compartmentId  string
-	topP           float32
-	topK           int32
-	maxTokens      int
-	stopSequences  []string
-	organizationId string
-	azureAPIType   string
+	backend         string
+	password        string
+	baseURL         string
+	endpointName    string
+	model           string
+	engine          string
+	temperature     float32
+	providerRegion  string
+	providerId      string
+	compartmentId   string
+	topP            float32
+	topK            int32
+	maxTokens       int
+	stopSequences   []string
+	organizationId  string
+	azureAPIType    string
+	azureAPIVersion string
 )
 
 var configAI ai.AIConfiguration

--- a/cmd/auth/provider_helpers.go
+++ b/cmd/auth/provider_helpers.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"github.com/fatih/color"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+)
+
+func newAIProviderFromAuthFlags(name string) ai.AIProvider {
+	return ai.AIProvider{
+		Name:            name,
+		Model:           model,
+		Password:        password,
+		BaseURL:         baseURL,
+		EndpointName:    endpointName,
+		Engine:          engine,
+		Temperature:     temperature,
+		ProviderRegion:  providerRegion,
+		ProviderId:      providerId,
+		CompartmentId:   compartmentId,
+		TopP:            topP,
+		TopK:            topK,
+		MaxTokens:       maxTokens,
+		StopSequences:   stopSequences,
+		OrganizationId:  organizationId,
+		AzureAPIType:    azureAPIType,
+		AzureAPIVersion: azureAPIVersion,
+	}
+}
+
+func applyAIProviderUpdates(provider *ai.AIProvider, name string) {
+	if name != "" {
+		provider.Name = name
+		color.Blue("Backend name updated successfully")
+	}
+	if model != "" {
+		provider.Model = model
+		color.Blue("Model updated successfully")
+	}
+	if password != "" {
+		provider.Password = password
+		color.Blue("Password updated successfully")
+	}
+	if baseURL != "" {
+		provider.BaseURL = baseURL
+		color.Blue("Base URL updated successfully")
+	}
+	if engine != "" {
+		provider.Engine = engine
+	}
+	if organizationId != "" {
+		provider.OrganizationId = organizationId
+		color.Blue("Organization Id updated successfully")
+	}
+	if azureAPIType != "" {
+		provider.AzureAPIType = azureAPIType
+		color.Blue("AzureAPIType updated successfully")
+	}
+	if azureAPIVersion != "" {
+		provider.AzureAPIVersion = azureAPIVersion
+		color.Blue("AzureAPIVersion updated successfully")
+	}
+	provider.Temperature = temperature
+}

--- a/cmd/auth/provider_helpers_test.go
+++ b/cmd/auth/provider_helpers_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func TestAddCommandPersistsAzureAPIVersion(t *testing.T) {
+	configureTestViper(t)
+	resetAuthFlagState(t)
+
+	setFlag(t, addCmd, "backend", "azureopenai")
+	setFlag(t, addCmd, "model", "gpt-4o")
+	setFlag(t, addCmd, "password", "token")
+	setFlag(t, addCmd, "baseurl", "https://example.openai.azure.com")
+	setFlag(t, addCmd, "engine", "deployment")
+	setFlag(t, addCmd, "temperature", "0.7")
+	setFlag(t, addCmd, "topp", "0.5")
+	setFlag(t, addCmd, "topk", "50")
+	setFlag(t, addCmd, "maxtokens", "2048")
+	setFlag(t, addCmd, "azureAPIVersion", "2024-02-15-preview")
+
+	addCmd.Run(addCmd, nil)
+
+	var cfg ai.AIConfiguration
+	if err := viper.UnmarshalKey("ai", &cfg); err != nil {
+		t.Fatalf("failed to unmarshal ai config: %v", err)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("expected one provider, got %d", len(cfg.Providers))
+	}
+	if cfg.Providers[0].AzureAPIVersion != "2024-02-15-preview" {
+		t.Fatalf("expected Azure API version to be persisted, got %q", cfg.Providers[0].AzureAPIVersion)
+	}
+}
+
+func TestUpdateCommandPersistsAzureAPIVersion(t *testing.T) {
+	configureTestViper(t)
+	resetAuthFlagState(t)
+
+	viper.Set("ai", ai.AIConfiguration{
+		Providers: []ai.AIProvider{{Name: "azureopenai", Model: "gpt-4o"}},
+	})
+	if err := viper.WriteConfig(); err != nil {
+		t.Fatalf("failed to write initial config: %v", err)
+	}
+
+	setFlag(t, updateCmd, "backend", "azureopenai")
+	setFlag(t, updateCmd, "temperature", "0.7")
+	setFlag(t, updateCmd, "azureAPIVersion", "2024-06-01")
+
+	updateCmd.Run(updateCmd, nil)
+
+	var cfg ai.AIConfiguration
+	if err := viper.UnmarshalKey("ai", &cfg); err != nil {
+		t.Fatalf("failed to unmarshal ai config: %v", err)
+	}
+	if len(cfg.Providers) != 1 {
+		t.Fatalf("expected one provider, got %d", len(cfg.Providers))
+	}
+	if cfg.Providers[0].AzureAPIVersion != "2024-06-01" {
+		t.Fatalf("expected Azure API version to be updated, got %q", cfg.Providers[0].AzureAPIVersion)
+	}
+}
+
+func TestNewAIProviderFromAuthFlagsIncludesAzureAPIVersion(t *testing.T) {
+	resetAuthFlagState(t)
+
+	model = "gpt-4o"
+	password = "token"
+	baseURL = "https://example.openai.azure.com"
+	endpointName = "endpoint"
+	engine = "deployment"
+	temperature = 0.2
+	providerRegion = "eastus"
+	providerId = "provider-id"
+	compartmentId = "compartment-id"
+	topP = 0.8
+	topK = 40
+	maxTokens = 1024
+	stopSequences = []string{"stop"}
+	organizationId = "org-id"
+	azureAPIType = "AZURE"
+	azureAPIVersion = "2024-02-15-preview"
+
+	provider := newAIProviderFromAuthFlags("azureopenai")
+
+	if provider.Name != "azureopenai" {
+		t.Fatalf("expected provider name azureopenai, got %q", provider.Name)
+	}
+	if provider.AzureAPIVersion != "2024-02-15-preview" {
+		t.Fatalf("expected Azure API version to be preserved, got %q", provider.AzureAPIVersion)
+	}
+	if !reflect.DeepEqual(provider.StopSequences, []string{"stop"}) {
+		t.Fatalf("expected stop sequences to be preserved, got %#v", provider.StopSequences)
+	}
+}
+
+func TestApplyAIProviderUpdatesIncludesAzureAPIVersion(t *testing.T) {
+	resetAuthFlagState(t)
+
+	model = "gpt-4o-mini"
+	password = "new-token"
+	baseURL = "https://example.openai.azure.com"
+	engine = "new-deployment"
+	temperature = 0.4
+	organizationId = "org-id"
+	azureAPIType = "AZURE_AD"
+	azureAPIVersion = "2024-06-01"
+
+	provider := ai.AIProvider{Name: "azureopenai"}
+	applyAIProviderUpdates(&provider, "azureopenai")
+
+	if provider.Model != "gpt-4o-mini" {
+		t.Fatalf("expected model to be updated, got %q", provider.Model)
+	}
+	if provider.AzureAPIVersion != "2024-06-01" {
+		t.Fatalf("expected Azure API version to be updated, got %q", provider.AzureAPIVersion)
+	}
+	if provider.Temperature != 0.4 {
+		t.Fatalf("expected temperature to be updated, got %v", provider.Temperature)
+	}
+}
+
+func resetAuthFlagState(t *testing.T) {
+	t.Helper()
+
+	backend = ""
+	password = ""
+	baseURL = ""
+	endpointName = ""
+	model = ""
+	engine = ""
+	temperature = 0
+	providerRegion = ""
+	providerId = ""
+	compartmentId = ""
+	topP = 0
+	topK = 0
+	maxTokens = 0
+	stopSequences = nil
+	organizationId = ""
+	azureAPIType = ""
+	azureAPIVersion = ""
+}
+
+func configureTestViper(t *testing.T) {
+	t.Helper()
+
+	viper.Reset()
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configFile, []byte("ai:\n  providers: []\n"), 0600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	viper.SetConfigFile(configFile)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("failed to read test config: %v", err)
+	}
+	t.Cleanup(viper.Reset)
+}
+
+func setFlag(t *testing.T, cmd interface{ Flags() *pflag.FlagSet }, name, value string) {
+	t.Helper()
+
+	if err := cmd.Flags().Set(name, value); err != nil {
+		t.Fatalf("failed to set %s flag: %v", name, err)
+	}
+}

--- a/cmd/auth/update.go
+++ b/cmd/auth/update.go
@@ -74,34 +74,7 @@ var updateCmd = &cobra.Command{
 		for i, provider := range configAI.Providers {
 			if backend == provider.Name {
 				foundBackend = true
-				if backend != "" {
-					configAI.Providers[i].Name = backend
-					color.Blue("Backend name updated successfully")
-				}
-				if model != "" {
-					configAI.Providers[i].Model = model
-					color.Blue("Model updated successfully")
-				}
-				if password != "" {
-					configAI.Providers[i].Password = password
-					color.Blue("Password updated successfully")
-				}
-				if baseURL != "" {
-					configAI.Providers[i].BaseURL = baseURL
-					color.Blue("Base URL updated successfully")
-				}
-				if engine != "" {
-					configAI.Providers[i].Engine = engine
-				}
-				if organizationId != "" {
-					configAI.Providers[i].OrganizationId = organizationId
-					color.Blue("Organization Id updated successfully")
-				}
-				if azureAPIType != "" {
-					configAI.Providers[i].AzureAPIType = azureAPIType
-					color.Blue("AzureAPIType updated successfully")
-				}
-				configAI.Providers[i].Temperature = temperature
+				applyAIProviderUpdates(&configAI.Providers[i], backend)
 				color.Green("%s updated in the AI backend provider list", backend)
 			}
 		}
@@ -135,4 +108,6 @@ func init() {
 	updateCmd.Flags().StringVarP(&organizationId, "organizationId", "o", "", "Update OpenAI or Azure organization Id")
 	// add flag for azure open ai APIType name
 	updateCmd.Flags().StringVarP(&azureAPIType, "azureAPIType", "a", "", fmt.Sprintf("AzureOpenAI API Type name. Valid values: %s, %s or %s (only for azureopenai backend)", openai.APITypeAzure, openai.APITypeAzureAD, openai.APITypeCloudflareAzure))
+	// add flag for azure open ai API version
+	updateCmd.Flags().StringVarP(&azureAPIVersion, "azureAPIVersion", "", "", "AzureOpenAI API version, e.g. 2024-02-15-preview")
 }

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -44,7 +44,7 @@ var (
 	mcpPort     string
 	mcpHTTP     bool
 	// filters can be injected into the server (repeatable flag)
-	filters     []string
+	filters []string
 )
 
 var ServeCmd = &cobra.Command{
@@ -140,34 +140,11 @@ var ServeCmd = &cobra.Command{
 				}
 				return []http.Header{header}
 			}
-			// Check for env injection
-			backend = os.Getenv("K8SGPT_BACKEND")
-			password := os.Getenv("K8SGPT_PASSWORD")
-			model := os.Getenv("K8SGPT_MODEL")
-			baseURL := os.Getenv("K8SGPT_BASEURL")
-			engine := os.Getenv("K8SGPT_ENGINE")
-			azureAPIType := os.Getenv("K8SGPT_AZURE_API_TYPE")
-			proxyEndpoint := os.Getenv("K8SGPT_PROXY_ENDPOINT")
-			providerId := os.Getenv("K8SGPT_PROVIDER_ID")
 			// If the envs are set, allocate in place to the aiProvider
 			// else exit with error
-			envIsSet := backend != "" || password != "" || model != ""
+			envProvider, envIsSet := providerFromEnv(parseCustomHeaders, temperature, topP, topK, maxTokens)
 			if envIsSet {
-				aiProvider = &ai.AIProvider{
-					Name:          backend,
-					Password:      password,
-					Model:         model,
-					BaseURL:       baseURL,
-					Engine:        engine,
-					AzureAPIType:  azureAPIType,
-					CustomHeaders: parseCustomHeaders(),
-					ProxyEndpoint: proxyEndpoint,
-					ProviderId:    providerId,
-					Temperature:   temperature(),
-					TopP:          topP(),
-					TopK:          topK(),
-					MaxTokens:     maxTokens(),
-				}
+				aiProvider = envProvider
 
 				configAI.Providers = append(configAI.Providers, *aiProvider)
 
@@ -257,6 +234,46 @@ var ServeCmd = &cobra.Command{
 		// Wait for both servers to exit
 		select {}
 	},
+}
+
+func providerFromEnv(
+	parseCustomHeaders func() []http.Header,
+	temperature func() float32,
+	topP func() float32,
+	topK func() int32,
+	maxTokens func() int,
+) (*ai.AIProvider, bool) {
+	backend = os.Getenv("K8SGPT_BACKEND")
+	password := os.Getenv("K8SGPT_PASSWORD")
+	model := os.Getenv("K8SGPT_MODEL")
+	baseURL := os.Getenv("K8SGPT_BASEURL")
+	engine := os.Getenv("K8SGPT_ENGINE")
+	azureAPIType := os.Getenv("K8SGPT_AZURE_API_TYPE")
+	azureAPIVersion := os.Getenv("K8SGPT_AZURE_API_VERSION")
+	proxyEndpoint := os.Getenv("K8SGPT_PROXY_ENDPOINT")
+	providerId := os.Getenv("K8SGPT_PROVIDER_ID")
+
+	envIsSet := backend != "" || password != "" || model != ""
+	if !envIsSet {
+		return nil, false
+	}
+
+	return &ai.AIProvider{
+		Name:            backend,
+		Password:        password,
+		Model:           model,
+		BaseURL:         baseURL,
+		Engine:          engine,
+		AzureAPIType:    azureAPIType,
+		AzureAPIVersion: azureAPIVersion,
+		CustomHeaders:   parseCustomHeaders(),
+		ProxyEndpoint:   proxyEndpoint,
+		ProviderId:      providerId,
+		Temperature:     temperature(),
+		TopP:            topP(),
+		TopK:            topK(),
+		MaxTokens:       maxTokens(),
+	}, true
 }
 
 func init() {

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serve
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestProviderFromEnvIncludesAzureAPIVersion(t *testing.T) {
+	t.Setenv("K8SGPT_BACKEND", "azureopenai")
+	t.Setenv("K8SGPT_PASSWORD", "token")
+	t.Setenv("K8SGPT_MODEL", "gpt-4o")
+	t.Setenv("K8SGPT_BASEURL", "https://example.openai.azure.com")
+	t.Setenv("K8SGPT_ENGINE", "deployment")
+	t.Setenv("K8SGPT_AZURE_API_TYPE", "AZURE")
+	t.Setenv("K8SGPT_AZURE_API_VERSION", "2024-02-15-preview")
+	t.Setenv("K8SGPT_PROXY_ENDPOINT", "http://proxy.example.com")
+	t.Setenv("K8SGPT_PROVIDER_ID", "provider-id")
+
+	headers := http.Header{}
+	headers.Set("x-test-header", "enabled")
+
+	provider, ok := providerFromEnv(
+		func() []http.Header { return []http.Header{headers} },
+		func() float32 { return 0.2 },
+		func() float32 { return 0.8 },
+		func() int32 { return 40 },
+		func() int { return 1024 },
+	)
+
+	if !ok {
+		t.Fatal("expected provider to be created from environment")
+	}
+	if provider.AzureAPIVersion != "2024-02-15-preview" {
+		t.Fatalf("expected Azure API version to be preserved, got %q", provider.AzureAPIVersion)
+	}
+	if provider.CustomHeaders[0].Get("x-test-header") != "enabled" {
+		t.Fatalf("expected custom headers to be preserved, got %#v", provider.CustomHeaders)
+	}
+	if provider.TopK != 40 || provider.MaxTokens != 1024 {
+		t.Fatalf("expected sampling settings to be preserved, got topK=%d maxTokens=%d", provider.TopK, provider.MaxTokens)
+	}
+}
+
+func TestProviderFromEnvReturnsFalseWhenUnset(t *testing.T) {
+	provider, ok := providerFromEnv(
+		func() []http.Header { return nil },
+		func() float32 { return 0 },
+		func() float32 { return 0 },
+		func() int32 { return 0 },
+		func() int { return 0 },
+	)
+
+	if ok {
+		t.Fatalf("expected no provider, got %#v", provider)
+	}
+}

--- a/pkg/ai/anthropic_test.go
+++ b/pkg/ai/anthropic_test.go
@@ -39,6 +39,7 @@ func (m *anthropicMockConfig) GetProviderId() string           { return "" }
 func (m *anthropicMockConfig) GetCompartmentId() string        { return "" }
 func (m *anthropicMockConfig) GetOrganizationId() string       { return "" }
 func (m *anthropicMockConfig) GetAzureAPIType() string         { return "" }
+func (m *anthropicMockConfig) GetAzureAPIVersion() string      { return "" }
 func (m *anthropicMockConfig) GetCustomHeaders() []http.Header { return m.customHeaders }
 
 func TestAnthropicClientGetCompletion(t *testing.T) {

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -3,7 +3,6 @@ package ai
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 
@@ -45,20 +44,16 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 	defaultConfig := openai.DefaultAzureConfig(token, baseURL)
 	orgId := config.GetOrganizationId()
 	azureAPIType := config.GetAzureAPIType()
+	azureAPIVersion := config.GetAzureAPIVersion()
 
-	defaultConfig.AzureModelMapperFunc = func(model string) string {
-		// If you use a deployment name different from the model name, you can customize the AzureModelMapperFunc function
-		azureModelMapping := map[string]string{
-			model: engine,
+	if engine != "" {
+		defaultConfig.AzureModelMapperFunc = func(model string) string {
+			return engine
 		}
-		return azureModelMapping[model]
-
 	}
 
 	customHeaders := config.GetCustomHeaders()
-	fmt.Println("azureopenai.go Custom Headers:", customHeaders)
 	if len(customHeaders) > 0 {
-		fmt.Println("azureopenai.go ( customHeaders > 0 ) Custom Headers:", customHeaders)
 		transport := &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 		}
@@ -83,6 +78,9 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 	}
 	if orgId != "" {
 		defaultConfig.OrgID = orgId
+	}
+	if azureAPIVersion != "" {
+		defaultConfig.APIVersion = azureAPIVersion
 	}
 
 	switch azureAPIType {

--- a/pkg/ai/azureopenai_test.go
+++ b/pkg/ai/azureopenai_test.go
@@ -12,30 +12,32 @@ import (
 
 // azureMockConfig implements IAIConfig for Azure OpenAI tests.
 type azureMockConfig struct {
-	baseURL       string
-	azureAPIType  string
-	customHeaders []http.Header
-	engine        string
-	proxyEndpoint string
-	organizationId string
+	baseURL         string
+	azureAPIType    string
+	azureAPIVersion string
+	customHeaders   []http.Header
+	engine          string
+	proxyEndpoint   string
+	organizationId  string
 }
 
-func (m *azureMockConfig) GetPassword() string        { return "test-token" }
-func (m *azureMockConfig) GetModel() string            { return "gpt-4" }
-func (m *azureMockConfig) GetBaseURL() string          { return m.baseURL }
-func (m *azureMockConfig) GetProxyEndpoint() string    { return m.proxyEndpoint }
-func (m *azureMockConfig) GetEndpointName() string     { return "" }
-func (m *azureMockConfig) GetEngine() string           { return m.engine }
-func (m *azureMockConfig) GetTemperature() float32     { return 0.0 }
-func (m *azureMockConfig) GetProviderRegion() string   { return "" }
-func (m *azureMockConfig) GetTopP() float32            { return 0.0 }
-func (m *azureMockConfig) GetTopK() int32              { return 0 }
-func (m *azureMockConfig) GetMaxTokens() int           { return 0 }
-func (m *azureMockConfig) GetStopSequences() []string  { return nil }
-func (m *azureMockConfig) GetProviderId() string       { return "" }
-func (m *azureMockConfig) GetCompartmentId() string    { return "" }
-func (m *azureMockConfig) GetOrganizationId() string   { return m.organizationId }
-func (m *azureMockConfig) GetAzureAPIType() string     { return m.azureAPIType }
+func (m *azureMockConfig) GetPassword() string             { return "test-token" }
+func (m *azureMockConfig) GetModel() string                { return "gpt-4" }
+func (m *azureMockConfig) GetBaseURL() string              { return m.baseURL }
+func (m *azureMockConfig) GetProxyEndpoint() string        { return m.proxyEndpoint }
+func (m *azureMockConfig) GetEndpointName() string         { return "" }
+func (m *azureMockConfig) GetEngine() string               { return m.engine }
+func (m *azureMockConfig) GetTemperature() float32         { return 0.0 }
+func (m *azureMockConfig) GetProviderRegion() string       { return "" }
+func (m *azureMockConfig) GetTopP() float32                { return 0.0 }
+func (m *azureMockConfig) GetTopK() int32                  { return 0 }
+func (m *azureMockConfig) GetMaxTokens() int               { return 0 }
+func (m *azureMockConfig) GetStopSequences() []string      { return nil }
+func (m *azureMockConfig) GetProviderId() string           { return "" }
+func (m *azureMockConfig) GetCompartmentId() string        { return "" }
+func (m *azureMockConfig) GetOrganizationId() string       { return m.organizationId }
+func (m *azureMockConfig) GetAzureAPIType() string         { return m.azureAPIType }
+func (m *azureMockConfig) GetAzureAPIVersion() string      { return m.azureAPIVersion }
 func (m *azureMockConfig) GetCustomHeaders() []http.Header { return m.customHeaders }
 
 // ---------------------------------------------------------------------------
@@ -174,6 +176,35 @@ func TestAzureAIClient_Configure_APIType(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestAzureAIClient_GetCompletion_UsesConfiguredAPIVersion(t *testing.T) {
+	requestReceived := make(chan *http.Request, 1)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestReceived <- r
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices": [{"message": {"content": "versioned response"}}]}`))
+	}))
+	defer server.Close()
+
+	config := &azureMockConfig{
+		baseURL:         server.URL,
+		engine:          "k8sgpt-deployment",
+		azureAPIVersion: "2024-02-15-preview",
+	}
+
+	client := &AzureAIClient{}
+	err := client.Configure(config)
+	require.NoError(t, err)
+
+	result, err := client.GetCompletion(context.Background(), "test prompt")
+	require.NoError(t, err)
+	assert.Equal(t, "versioned response", result)
+
+	request := <-requestReceived
+	assert.Equal(t, "2024-02-15-preview", request.URL.Query().Get("api-version"))
+	assert.Contains(t, request.URL.Path, "/openai/deployments/k8sgpt-deployment/chat/completions")
 }
 
 func TestAzureAIClient_Configure_CustomHeaders(t *testing.T) {

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -94,6 +94,7 @@ type IAIConfig interface {
 	GetCompartmentId() string
 	GetOrganizationId() string
 	GetAzureAPIType() string
+	GetAzureAPIVersion() string
 	GetCustomHeaders() []http.Header
 }
 
@@ -113,25 +114,26 @@ type AIConfiguration struct {
 }
 
 type AIProvider struct {
-	Name           string        `mapstructure:"name"`
-	Model          string        `mapstructure:"model"`
-	Password       string        `mapstructure:"password" yaml:"password,omitempty"`
-	BaseURL        string        `mapstructure:"baseurl" yaml:"baseurl,omitempty"`
-	ProxyEndpoint  string        `mapstructure:"proxyEndpoint" yaml:"proxyEndpoint,omitempty"`
-	ProxyPort      string        `mapstructure:"proxyPort" yaml:"proxyPort,omitempty"`
-	EndpointName   string        `mapstructure:"endpointname" yaml:"endpointname,omitempty"`
-	Engine         string        `mapstructure:"engine" yaml:"engine,omitempty"`
-	Temperature    float32       `mapstructure:"temperature" yaml:"temperature,omitempty"`
-	ProviderRegion string        `mapstructure:"providerregion" yaml:"providerregion,omitempty"`
-	ProviderId     string        `mapstructure:"providerid" yaml:"providerid,omitempty"`
-	CompartmentId  string        `mapstructure:"compartmentid" yaml:"compartmentid,omitempty"`
-	TopP           float32       `mapstructure:"topp" yaml:"topp,omitempty"`
-	TopK           int32         `mapstructure:"topk" yaml:"topk,omitempty"`
-	MaxTokens      int           `mapstructure:"maxtokens" yaml:"maxtokens,omitempty"`
-	StopSequences  []string      `mapstructure:"stopsequences" yaml:"stopsequences,omitempty"`
-	OrganizationId string        `mapstructure:"organizationid" yaml:"organizationid,omitempty"`
-	AzureAPIType   string        `mapstructure:"azureapitype" yaml:"azureapitype,omitempty"`
-	CustomHeaders  []http.Header `mapstructure:"customHeaders"`
+	Name            string        `mapstructure:"name"`
+	Model           string        `mapstructure:"model"`
+	Password        string        `mapstructure:"password" yaml:"password,omitempty"`
+	BaseURL         string        `mapstructure:"baseurl" yaml:"baseurl,omitempty"`
+	ProxyEndpoint   string        `mapstructure:"proxyEndpoint" yaml:"proxyEndpoint,omitempty"`
+	ProxyPort       string        `mapstructure:"proxyPort" yaml:"proxyPort,omitempty"`
+	EndpointName    string        `mapstructure:"endpointname" yaml:"endpointname,omitempty"`
+	Engine          string        `mapstructure:"engine" yaml:"engine,omitempty"`
+	Temperature     float32       `mapstructure:"temperature" yaml:"temperature,omitempty"`
+	ProviderRegion  string        `mapstructure:"providerregion" yaml:"providerregion,omitempty"`
+	ProviderId      string        `mapstructure:"providerid" yaml:"providerid,omitempty"`
+	CompartmentId   string        `mapstructure:"compartmentid" yaml:"compartmentid,omitempty"`
+	TopP            float32       `mapstructure:"topp" yaml:"topp,omitempty"`
+	TopK            int32         `mapstructure:"topk" yaml:"topk,omitempty"`
+	MaxTokens       int           `mapstructure:"maxtokens" yaml:"maxtokens,omitempty"`
+	StopSequences   []string      `mapstructure:"stopsequences" yaml:"stopsequences,omitempty"`
+	OrganizationId  string        `mapstructure:"organizationid" yaml:"organizationid,omitempty"`
+	AzureAPIType    string        `mapstructure:"azureapitype" yaml:"azureapitype,omitempty"`
+	AzureAPIVersion string        `mapstructure:"azureapiversion" yaml:"azureapiversion,omitempty"`
+	CustomHeaders   []http.Header `mapstructure:"customHeaders"`
 }
 
 func (p *AIProvider) GetBaseURL() string {
@@ -195,6 +197,10 @@ func (p *AIProvider) GetOrganizationId() string {
 
 func (p *AIProvider) GetAzureAPIType() string {
 	return p.AzureAPIType
+}
+
+func (p *AIProvider) GetAzureAPIVersion() string {
+	return p.AzureAPIVersion
 }
 
 func (p *AIProvider) GetCustomHeaders() []http.Header {

--- a/pkg/ai/iai_test.go
+++ b/pkg/ai/iai_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import "testing"
+
+func TestAIProviderGetAzureAPIVersion(t *testing.T) {
+	provider := AIProvider{AzureAPIVersion: "2024-02-15-preview"}
+
+	if got := provider.GetAzureAPIVersion(); got != "2024-02-15-preview" {
+		t.Fatalf("expected Azure API version to be returned, got %q", got)
+	}
+}

--- a/pkg/ai/openai_header_transport_test.go
+++ b/pkg/ai/openai_header_transport_test.go
@@ -84,6 +84,10 @@ func (m *mockConfig) GetAzureAPIType() string {
 	return ""
 }
 
+func (m *mockConfig) GetAzureAPIVersion() string {
+	return ""
+}
+
 func TestOpenAIClient_CustomHeaders(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "Value1", r.Header.Get("X-Custom-Header-1"))


### PR DESCRIPTION
## Description

Adds Azure OpenAI API version configuration support for the `azureopenai` provider.

The API version can now be set through:

- `k8sgpt auth add --azureAPIVersion`
- `k8sgpt auth update --azureAPIVersion`
- `K8SGPT_AZURE_API_VERSION` when running `k8sgpt serve`
- the persisted provider config

When present, the value is passed to the Azure OpenAI client configuration so users can opt into newer Azure OpenAI API versions without changing code.

## Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

Validated locally:

- `GOCACHE=/private/tmp/k8sgpt-go-build go test ./cmd/auth ./cmd/serve`
- `GOCACHE=/private/tmp/k8sgpt-go-build go test ./pkg/ai`

## Additional Information

The `pkg/ai` test package uses local `httptest` servers, so it needs permission to bind a localhost listener in restricted environments.
