### PR TITLE
fix: guard against empty conditions in Gateway/GatewayClass analyzers

### DIFF
--- a/pkg/analyzer/gateway.go
+++ b/pkg/analyzer/gateway.go
@@ -74,7 +74,7 @@ func (GatewayAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 
 		// Check only the current conditions
 		// TODO: maybe check other statuses Listeners, addresses?
-		if gtw.Status.Conditions[0].Status != metav1.ConditionTrue {
+		if len(gtw.Status.Conditions) > 0 && gtw.Status.Conditions[0].Status != metav1.ConditionTrue {
 			failures = append(failures, common.Failure{
 				Text: fmt.Sprintf("Gateway '%s/%s' is not accepted. Message: '%s'.",
 					gtwNamespace,

--- a/pkg/analyzer/gateway_test.go
+++ b/pkg/analyzer/gateway_test.go
@@ -91,6 +91,49 @@ func TestGatewayAnalyzer(t *testing.T) {
 
 }
 
+func TestEmptyConditionsGatewayAnalyzer(t *testing.T) {
+	ClassName := gtwapi.ObjectName("exists")
+	AcceptedStatus := metav1.ConditionTrue
+	GatewayClass := BuildGatewayClass(string(ClassName))
+
+	Gateway := BuildGateway(ClassName, AcceptedStatus, nil)
+	// A freshly created Gateway (or one whose controller has not reported yet)
+	// has no status conditions; the analyzer must not panic on it.
+	Gateway.Status.Conditions = nil
+	// Create a Gateway Analyzer instance with the fake client
+	scheme := scheme.Scheme
+
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{
+		&Gateway,
+		&GatewayClass,
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := GatewayAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
+
+}
+
 func TestMissingClassGatewayAnalyzer(t *testing.T) {
 	ClassName := gtwapi.ObjectName("non-existed")
 	AcceptedStatus := metav1.ConditionTrue

--- a/pkg/analyzer/gatewayclass.go
+++ b/pkg/analyzer/gatewayclass.go
@@ -53,7 +53,7 @@ func (GatewayClassAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 
 		gcName := gc.GetName()
 		// Check only the current condition
-		if gc.Status.Conditions[0].Status != metav1.ConditionTrue {
+		if len(gc.Status.Conditions) > 0 && gc.Status.Conditions[0].Status != metav1.ConditionTrue {
 			failures = append(failures, common.Failure{
 				Text: fmt.Sprintf(
 					"GatewayClass '%s' with a controller name '%s' is not accepted. Message: '%s'.",

--- a/pkg/analyzer/gatewayclass_test.go
+++ b/pkg/analyzer/gatewayclass_test.go
@@ -56,6 +56,41 @@ func TestGatewayClassAnalyzer(t *testing.T) {
 
 }
 
+// A GatewayClass with no status conditions (newly created, or no controller
+// installed) must not panic the analyzer.
+func TestEmptyConditionsGatewayClassAnalyzer(t *testing.T) {
+	GatewayClass := &gtwapi.GatewayClass{}
+	GatewayClass.Name = "foobar"
+	GatewayClass.Spec.ControllerName = "gateway.fooproxy.io/gatewayclass-controller"
+	// Create a GatewayClassAnalyzer instance with the fake client
+	scheme := scheme.Scheme
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(GatewayClass).Build()
+
+	analyzerInstance := GatewayClassAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
+
+}
+
 func TestGatewayClassAnalyzerLabelSelectorFiltering(t *testing.T) {
 	condition := metav1.Condition{
 		Type:    "Accepted",


### PR DESCRIPTION
Closes #1669

## 📑 Description

The Gateway and GatewayClass analyzers index `Status.Conditions[0]` with no length check. A Gateway or GatewayClass with empty `status.conditions` (a brand-new object before its controller writes status, or a cluster with no Gateway controller installed) panics the whole `k8sgpt analyze` run with `index out of range [0] with length 0`.

This mirrors the fix the PodDisruptionBudget analyzer received in #664: short-circuit on `len(...Conditions) > 0` before reading `[0]`, so the object is simply skipped.

- `pkg/analyzer/gateway.go`: `if len(gtw.Status.Conditions) > 0 && gtw.Status.Conditions[0].Status != metav1.ConditionTrue`
- `pkg/analyzer/gatewayclass.go`: same guard for `gc.Status.Conditions[0]`

Added `TestEmptyConditionsGatewayAnalyzer` and `TestEmptyConditionsGatewayClassAnalyzer` (empty conditions -> 0 results, no panic). Both panic on the unpatched source, so they actually exercise the bug.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

No behavior change for Gateways/GatewayClasses that already report conditions. `gofmt`, `go vet ./pkg/analyzer/...`, `go build`, and `go test ./pkg/analyzer/...` all pass.
