### PR TITLE
fix: guard against nil TargetRef in Service not-ready endpoints

### DIFF
--- a/pkg/analyzer/service.go
+++ b/pkg/analyzer/service.go
@@ -96,7 +96,9 @@ func (ServiceAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 				if len(epSubset.NotReadyAddresses) > 0 {
 					for _, addresses := range epSubset.NotReadyAddresses {
 						count++
-						pods = append(pods, addresses.TargetRef.Kind+"/"+addresses.TargetRef.Name)
+						if addresses.TargetRef != nil {
+							pods = append(pods, addresses.TargetRef.Kind+"/"+addresses.TargetRef.Name)
+						}
 					}
 				}
 			}

--- a/pkg/analyzer/service_test.go
+++ b/pkg/analyzer/service_test.go
@@ -121,6 +121,53 @@ func TestServiceAnalyzer(t *testing.T) {
 			},
 		},
 		{
+			name: "Service with not ready endpoints with nil TargetRef",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Endpoints{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-service",
+								Namespace: "default",
+							},
+							Subsets: []v1.EndpointSubset{
+								{
+									// Not-ready address with no TargetRef (bare-IP /
+									// manually-created Endpoints, not backed by a Pod).
+									NotReadyAddresses: []v1.EndpointAddress{
+										{
+											IP: "10.0.0.1",
+										},
+									},
+								},
+							},
+						},
+						&v1.Service{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-service",
+								Namespace: "default",
+							},
+							Spec: v1.ServiceSpec{
+								Selector: map[string]string{
+									"app": "test",
+								},
+							},
+						},
+					),
+				},
+				Namespace: "default",
+			},
+			expectations: []struct {
+				name          string
+				failuresCount int
+			}{
+				{
+					name:          "default/test-service",
+					failuresCount: 1, // One failure for not ready endpoints
+				},
+			},
+		},
+		{
 			name: "Service with warning events",
 			config: common.Analyzer{
 				Client: &kubernetes.Client{


### PR DESCRIPTION
Closes #1671

## 📑 Description

The Service analyzer dereferences `EndpointAddress.TargetRef` while building the not-ready pod list, but `TargetRef` is optional (`*v1.ObjectReference`, marked `+optional` in `k8s.io/api`) and is nil for endpoint addresses not backed by a Pod, for example bare-IP addresses or manually-created `Endpoints`. A single not-ready address of that kind panics the whole `k8sgpt analyze` run with `invalid memory address or nil pointer dereference` at `pkg/analyzer/service.go:99`.

This only appends the `Kind/Name` pod label when `TargetRef != nil`. The address is still counted, so the "Service has not ready endpoints" failure is reported exactly as before; the crash just goes away. This mirrors the existing nil/empty guards added in #653 and #664.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Adds a regression test (`service_test.go`) for a not-ready endpoint address with no `TargetRef`. Verified that reverting only the guard makes the new test panic at `pkg/analyzer/service.go:99`, and restoring it makes the suite pass. `go build`, `gofmt -l`, `go vet ./pkg/analyzer/...`, and `go test ./pkg/analyzer/...` all pass. No behavior change for Services that already had Pod-backed endpoints. Commit is DCO signed-off.
