### PR TITLE
fix: detect SchedulingGated pods (#1474)

### DIFF
--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -57,6 +57,16 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						})
 					}
 				}
+				if containerStatus.Type == v1.PodScheduled && containerStatus.Reason == v1.PodReasonSchedulingGated {
+					text := containerStatus.Message
+					if text == "" {
+						text = fmt.Sprintf("Pod %s/%s is in a SchedulingGated state and is blocked from scheduling due to non-empty scheduling gates", pod.Namespace, pod.Name)
+					}
+					failures = append(failures, common.Failure{
+						Text:      text,
+						Sensitive: []common.Sensitive{},
+					})
+				}
 			}
 		}
 

--- a/pkg/analyzer/pod_test.go
+++ b/pkg/analyzer/pod_test.go
@@ -120,6 +120,66 @@ func TestPodAnalyzer(t *testing.T) {
 			},
 		},
 		{
+			name: "SchedulingGated pods with and without a message",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "GatedPod1",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Phase: v1.PodPending,
+								Conditions: []v1.PodCondition{
+									{
+										// A gated pod usually has an empty message;
+										// a default message is generated instead.
+										Type:   v1.PodScheduled,
+										Status: v1.ConditionFalse,
+										Reason: v1.PodReasonSchedulingGated,
+									},
+								},
+							},
+						},
+						&v1.Pod{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "GatedPod2",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Phase: v1.PodPending,
+								Conditions: []v1.PodCondition{
+									{
+										// When a message is present, it is surfaced as-is.
+										Type:    v1.PodScheduled,
+										Status:  v1.ConditionFalse,
+										Reason:  v1.PodReasonSchedulingGated,
+										Message: "Scheduling is blocked due to non-empty scheduling gates",
+									},
+								},
+							},
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			expectations: []struct {
+				name          string
+				failuresCount int
+			}{
+				{
+					name:          "default/GatedPod1",
+					failuresCount: 1,
+				},
+				{
+					name:          "default/GatedPod2",
+					failuresCount: 1,
+				},
+			},
+		},
+		{
 			name: "Evicted pod with message",
 			config: common.Analyzer{
 				Client: &kubernetes.Client{


### PR DESCRIPTION
Closes #1474

## 📑 Description

The Pod analyzer reported scheduling-gated pods as healthy. A pod with a
non-empty `.spec.schedulingGates` stays in the `Pending` phase with a
`PodScheduled` condition of `Status=False, Reason=SchedulingGated`. The analyzer
only matched the `Unschedulable` reason, so a gated pod fell through every branch
and showed up with "no problems detected" even though it is blocked from
scheduling.

This adds a sibling check on the `PodScheduled` condition for the
`SchedulingGated` reason, right next to the existing `Unschedulable` check. Gated
pods commonly carry an empty condition message, so it emits a default message
that names the pod when none is present, and surfaces the condition message
otherwise (mirroring how the `Unschedulable` branch reports).

This is the residual half of #1474. The suspended Job/CronJob half is already
handled in `pkg/analyzer/job.go` and `pkg/analyzer/cronjob.go`, so this scopes
strictly to the scheduling-gated pod gap the issue author flagged as
outstanding.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Added a table-driven case in `pkg/analyzer/pod_test.go` covering a gated pod with
an empty condition message (default text generated) and one with a message (passed
through). Uses the existing client-go fake client, so no cluster, Docker, or API
key is needed. New code uses the exported `v1.PodReasonSchedulingGated` constant;
the pre-existing `Unschedulable` string literal was left untouched to keep the
diff surgical.
