### PR TITLE
fix(hpa): stop flagging HPAs idling at their minimum replica count

### DIFF
--- a/pkg/analyzer/hpa.go
+++ b/pkg/analyzer/hpa.go
@@ -60,7 +60,14 @@ func (HpaAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			// https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#appendix-horizontal-pod-autoscaler-status-conditions
 			switch condition.Type {
 			case autoscalingv2.ScalingLimited:
-				if condition.Status == corev1.ConditionTrue {
+				// ScalingLimited=True is a routine status indicator, not inherently an
+				// error. In particular, TooFewReplicas fires whenever the HPA is idling
+				// at its minimum replica floor (desired == min), which is expected and
+				// healthy. Only flag it when it reflects an actionable limitation.
+				atMinReplicas := hpa.Spec.MinReplicas != nil &&
+					hpa.Status.DesiredReplicas == *hpa.Spec.MinReplicas
+				idleAtFloor := condition.Reason == "TooFewReplicas" && atMinReplicas
+				if condition.Status == corev1.ConditionTrue && !idleAtFloor {
 					failures = append(failures, common.Failure{
 						Text:      condition.Message,
 						Sensitive: []common.Sensitive{},

--- a/pkg/analyzer/hpa_test.go
+++ b/pkg/analyzer/hpa_test.go
@@ -501,6 +501,128 @@ func TestHPAAnalyzerWithExistingScaleTargetRefWithoutSpecifyingResources(t *test
 	}
 }
 
+func TestHPAAnalyzerScalingLimitedTooFewReplicasAtMinIgnored(t *testing.T) {
+	// An HPA idling at its minimum replica floor reports
+	// ScalingLimited=True, reason=TooFewReplicas. This is normal, healthy
+	// behavior and must not be flagged as a failure. See issue #1667.
+	minReplicas := int32(2)
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				MinReplicas: &minReplicas,
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "example",
+				},
+			},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				DesiredReplicas: minReplicas,
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{
+						Type:    autoscalingv2.ScalingLimited,
+						Status:  "True",
+						Reason:  "TooFewReplicas",
+						Message: "the desired replica count is less than the minimum replica count",
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "example",
+								Image: "nginx",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("100m"),
+										"memory": resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse("200m"),
+										"memory": resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	// The HPA is healthy, so it should produce no analysis results at all.
+	assert.Equal(t, len(analysisResults), 0)
+}
+
+func TestHPAAnalyzerScalingLimitedTooFewReplicasAboveMinFlagged(t *testing.T) {
+	// TooFewReplicas while desired > min is not the routine idle case and
+	// should still be surfaced.
+	minReplicas := int32(2)
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				MinReplicas: &minReplicas,
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "example",
+				},
+			},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				DesiredReplicas: 4,
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{
+						Type:    autoscalingv2.ScalingLimited,
+						Status:  "True",
+						Reason:  "TooFewReplicas",
+						Message: "the desired replica count is less than the minimum replica count",
+					},
+				},
+			},
+		})
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+}
+
 func TestHPAAnalyzerNamespaceFiltering(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&autoscalingv2.HorizontalPodAutoscaler{


### PR DESCRIPTION
## Problem

The HPA analyzer (`pkg/analyzer/hpa.go`) treated any `ScalingLimited=True` condition as a failure, inspecting only `condition.Status` and never `condition.Reason`. An HPA idling at its minimum replica floor reports `ScalingLimited=True, reason=TooFewReplicas` with `desired == current == min` — normal, healthy behaviour. This produced false-positive Result CRs that fired alerts every reconcile cycle.

## Fix

Skip the `ScalingLimited` failure when `reason == TooFewReplicas` **and** the desired replica count equals the configured minimum. All other `ScalingLimited` reasons, and `TooFewReplicas` above the floor, are still surfaced.

## Tests

- Added `TestHPAAnalyzerScalingLimitedTooFewReplicasAtMinIgnored` — idle-at-floor HPA produces no results.
- Added `TestHPAAnalyzerScalingLimitedTooFewReplicasAboveMinFlagged` — `TooFewReplicas` above the floor is still flagged.
- Existing `ScalingLimited` tests unchanged and passing (they don't set `reason`/`minReplicas`, so behaviour is unchanged).

Fixes #1667

🤖 Generated with [Claude Code](https://claude.com/claude-code)