### PR TITLE
fix: correct Vertex AI legacy model ids by removing stray asterisk

### DIFF
--- a/pkg/ai/googlevertexai.go
+++ b/pkg/ai/googlevertexai.go
@@ -66,8 +66,8 @@ const (
 	ModelGeminiFlashV2_5   = "gemini-2.5-flash"      // Latest Stable Model
 	ModelGeminiFlashV2     = "gemini-2.0-flash"      // Latest Stable Model
 	ModelGeminiFlashLiteV2 = "gemini-2.0-flash-lite" // Latest Stable Model
-	ModelGeminiProV1_5     = "gemini-1.5-pro-002*"   // Legacy Stable Model
-	ModelGeminiFlashV1_5   = "gemini-1.5-flash-002*" // Legacy Stable Model
+	ModelGeminiProV1_5     = "gemini-1.5-pro-002"    // Legacy Stable Model
+	ModelGeminiFlashV1_5   = "gemini-1.5-flash-002"  // Legacy Stable Model
 )
 
 var VERTEXAI_MODELS = []string{

--- a/pkg/ai/googlevertexai_test.go
+++ b/pkg/ai/googlevertexai_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVertexAIModelOrDefault(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{"latest stable pro is preserved", ModelGeminiProV2_5, "gemini-2.5-pro"},
+		{"legacy stable pro is preserved", "gemini-1.5-pro-002", "gemini-1.5-pro-002"},
+		{"legacy stable flash is preserved", "gemini-1.5-flash-002", "gemini-1.5-flash-002"},
+		{"unknown model falls back to default", "does-not-exist", VERTEXAI_MODELS[0]},
+		{"empty model falls back to default", "", VERTEXAI_MODELS[0]},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetVertexAIModelOrDefault(tt.model))
+		})
+	}
+}
+
+func TestGetVertexAIRegionOrDefault(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		want   string
+	}{
+		{"supported region is preserved", US_West_4, "us-west4"},
+		{"unknown region falls back to default", "moon-base-1", VERTEXAI_DEFAULT_REGION},
+		{"empty region falls back to default", "", VERTEXAI_DEFAULT_REGION},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, GetVertexAIRegionOrDefault(tt.region))
+		})
+	}
+}


### PR DESCRIPTION

```markdown
Closes #1516

## 📑 Description

The two Vertex AI "Legacy Stable Model" constants in `pkg/ai/googlevertexai.go`
carried a trailing `*` inside the string literal:

- `ModelGeminiProV1_5 = "gemini-1.5-pro-002*"`
- `ModelGeminiFlashV1_5 = "gemini-1.5-flash-002*"`

The `*` is the footnote marker from Google's model-versions / lifecycle table, not
part of the model id. Every other id in the same block is a clean identifier
(`gemini-2.5-pro`, `gemini-2.0-flash`, `gemini-1.0-pro-001`, ...), so the asterisk
is clearly a copy/paste artifact.

Because `GetVertexAIModelOrDefault` does an exact-match lookup and otherwise
silently returns `VERTEXAI_MODELS[0]`, and `VERTEXAI_MODELS` held the asterisked
values, a user who correctly configured `gemini-1.5-pro-002` failed the exact match
and was silently downgraded to the default model. The two legacy models could never
be selected. This is the behavior reported in #1516 ("Configured model does not
load").

The fix removes the trailing `*` from both literals so the configured id matches,
and adds a unit test covering the model and region resolvers (no client/network
required).

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Root cause introduced in #1539 ("feat: add latest and legacy stable models"), where
both literals were added already carrying the `*` while the sibling ids it added are
clean. Diff is two literals plus a new `pkg/ai/googlevertexai_test.go`; no other file
references the asterisked form.

Verification:
- `gofmt -l pkg/ai/googlevertexai.go pkg/ai/googlevertexai_test.go` -> empty
- `go vet ./pkg/ai/...` -> ok
- `go build ./...` -> ok
- `go test ./pkg/ai/ -run TestGetVertexAI -v` -> PASS (8 subtests)
- Regression proof: re-adding the `*` makes the two legacy-model subtests fail
  (they return `gemini-2.5-pro` = the default) and removing it makes them pass.
```

---

## Post-open action (ship time, per CONTRIBUTING - non-org contributor)

Comment on #1516 to claim it, e.g.:

> I dug into this: the two Vertex AI "Legacy Stable Model" constants in
> `pkg/ai/googlevertexai.go` have a trailing `*` from the docs footnote marker, so a
> correctly configured `gemini-1.5-pro-002` fails the exact-match lookup in
> `GetVertexAIModelOrDefault` and silently falls back to the default. Opened a small
> PR removing the asterisk with a regression test. Happy to adjust.
