### PR TITLE
fix: point release-please extra-files at the real chart path

### DIFF
--- a/charts/k8sgpt/Chart.yaml
+++ b/charts/k8sgpt/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.4.23 #x-release-please-version
+appVersion: v0.4.35 #x-release-please-version
 description: A Helm chart for K8SGPT
 name: k8sgpt
 type: application

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,10 +9,10 @@
       "draft": false,
       "extra-files": [
         "README.md",
-        "deploy/manifest.yaml",
-        "chart/Chart.yaml",
-        "chart/values.yaml",
-        "container/manifests/deployment.yaml"
+        {
+          "type": "generic",
+          "path": "charts/k8sgpt/Chart.yaml"
+        }
       ],
       "changelog-sections": [
         {


### PR DESCRIPTION

Closes #<ISSUE>


The `extra-files` list in `release-please-config.json` referenced four paths that
do not exist in the repository:

- `deploy/manifest.yaml`
- `chart/Chart.yaml`
- `chart/values.yaml`
- `container/manifests/deployment.yaml`

The real Helm chart lives at `charts/k8sgpt/`. release-please silently skips
missing extra-files (`createIfMissing` is false), so the
`#x-release-please-version` marker in `charts/k8sgpt/Chart.yaml` was never bumped
and its `appVersion` stayed frozen at `v0.4.23` while releases advanced to
`v0.4.35`. (`README.md` is listed correctly and its version blocks are already at
v0.4.35, which shows the mechanism only works for correctly-pathed files.)

Because the chart's default image tag falls back to `.Chart.AppVersion`
(`values.yaml`: `tag: "" # defaults to Chart.appVersion if unspecified`;
`templates/deployment.yaml`: `{{ .Values.deployment.image.tag | default
.Chart.AppVersion }}`), a default `helm install charts/k8sgpt` deployed a stale
image and stamped `app.kubernetes.io/version: v0.4.23` on the rendered resources.

This change:

1. Points `extra-files` at the file that actually carries the marker,
   `charts/k8sgpt/Chart.yaml`, and drops the four non-existent paths.
2. Bumps `appVersion` in `charts/k8sgpt/Chart.yaml` to the current `v0.4.35` so
   the chart is correct now; release-please keeps it in sync from here on.

The chart is listed with `type: "generic"` rather than as a plain string on
purpose. A plain `.yaml` string makes release-please run `GenericYaml($.version)`
before the `Generic` updater; `GenericYaml` re-serializes the document with a
parser that drops all comments, which would delete the `#x-release-please-version`
marker and rewrite the unrelated chart `version` field. The `generic` type runs
only the comment-aware `Generic` updater, so it bumps `appVersion` on the
annotated line and leaves the marker and the chart `version` intact.
`charts/k8sgpt/values.yaml` has no version marker, so it is not listed.

## Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## Additional Information

No runtime Go code is changed (config + one chart line). The chart's own
`version` field is intentionally left unmanaged by release-please.

Verification performed locally:
- `python3 -m json.tool release-please-config.json` -> valid JSON.
- Validated `release-please-config.json` against the upstream release-please
  `schemas/config.json` (draft-07) -> schema valid (the `extra-files` `anyOf` has
  a dedicated `generic` variant requiring only `type` + `path`).
- `git ls-files --error-unmatch` resolves both listed extra-files (`README.md`,
  `charts/k8sgpt/Chart.yaml`); before this change, 4 of 5 did not exist.
- `go build -o k8sgpt .` -> OK.
