### PR TITLE
fix: guard empty API key in Google GenAI client

### DIFF
--- a/pkg/ai/googlegenai.go
+++ b/pkg/ai/googlegenai.go
@@ -41,7 +41,7 @@ func (c *GoogleGenAIClient) Configure(config IAIConfig) error {
 	// Access your API key as an environment variable (see "Set up your API key" above)
 	token := config.GetPassword()
 	authOption := option.WithAPIKey(token)
-	if token[0] == '{' {
+	if len(token) > 0 && token[0] == '{' {
 		authOption = option.WithCredentialsJSON([]byte(token))
 	}
 

--- a/pkg/ai/googlegenai_test.go
+++ b/pkg/ai/googlegenai_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoogleGenAIClientConfigureEmptyPassword(t *testing.T) {
+	client := &GoogleGenAIClient{}
+
+	var err error
+	require.NotPanics(t, func() {
+		err = client.Configure(&AIProvider{Name: googleAIClientName, Password: ""})
+	})
+	require.Error(t, err)
+}
+
+func TestGoogleGenAIClientConfigureAPIKey(t *testing.T) {
+	client := &GoogleGenAIClient{}
+
+	require.NoError(t, client.Configure(&AIProvider{Name: googleAIClientName, Password: "test-key"}))
+	client.Close()
+}
+
+func TestGoogleGenAIClientConfigureInvalidCredentialsJSON(t *testing.T) {
+	client := &GoogleGenAIClient{}
+
+	require.Error(t, client.Configure(&AIProvider{Name: googleAIClientName, Password: "{"}))
+}


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #

## 📑 Description
`GoogleGenAIClient.Configure` reads the first byte of the password token to detect
a JSON service-account credential:

```go
token := config.GetPassword()
authOption := option.WithAPIKey(token)
if token[0] == '{' {
    authOption = option.WithCredentialsJSON([]byte(token))
}
```

The `google` backend is not in `passwordlessProviders`, so a password is expected,
but nothing enforces a non-empty value. When the stored/entered API key is empty,
`token[0]` indexes an empty string and `Configure` panics:

```
panic: runtime error: index out of range [0] with length 0
```

This adds a `len(token) > 0` guard before indexing, matching how the sibling
clients handle an empty key (`pkg/ai/watsonxai.go` checks `apiKey == ""` and
`pkg/ai/anthropic.go` checks `token != ""` before using it). With an empty
password, `Configure` now falls through to `option.WithAPIKey("")` and returns the
Google SDK's normal authentication error instead of crashing.

A regression test (`pkg/ai/googlegenai_test.go`) asserts that `Configure` with an
empty password does not panic and returns an error. It fails with the exact
`index out of range [0] with length 0` panic without the guard and passes with it.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
No behavior change for a valid API key or JSON credential; the guard only affects
the previously-panicking empty-key path. Verified locally with
`go test ./pkg/ai/...` (pass), `go vet ./pkg/ai/...`, `gofmt -l`, and `go build .`.
