### PR TITLE
fix: clamp max-concurrency in custom analysis to avoid deadlock and panic

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -260,7 +260,16 @@ func (a *Analysis) RunCustomAnalysis() {
 		return
 	}
 
-	semaphore := make(chan struct{}, a.MaxConcurrency)
+	// Set a reasonable maximum for concurrency to prevent excessive memory allocation
+	const maxAllowedConcurrency = 100
+	concurrency := a.MaxConcurrency
+	if concurrency <= 0 {
+		concurrency = 10 // Default value if not set
+	} else if concurrency > maxAllowedConcurrency {
+		concurrency = maxAllowedConcurrency // Cap at a reasonable maximum
+	}
+
+	semaphore := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
 	var mutex sync.Mutex
 	verbose := viper.GetBool("verbose")

--- a/pkg/analysis/analysis_test.go
+++ b/pkg/analysis/analysis_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
@@ -632,6 +633,48 @@ func TestVerbose_RunCustomAnalysisWithCustomAnalyzer(t *testing.T) {
 			t.Errorf("Expected output to contain: '%s', but got output: '%s'", expected, output)
 		}
 	}
+}
+
+// Test: RunCustomAnalysis must not deadlock when MaxConcurrency is 0.
+// A non-positive value previously produced an unbuffered semaphore whose only
+// receiver is launched after the blocking send, hanging the command forever.
+func TestRunCustomAnalysisZeroConcurrency(t *testing.T) {
+	viper.Set("custom_analyzers", []map[string]interface{}{
+		{
+			"name":       "TestCustomAnalyzer",
+			"connection": map[string]interface{}{"url": "127.0.0.1", "port": "2333"},
+		},
+	})
+
+	analysisObj := &Analysis{
+		MaxConcurrency: 0,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		analysisObj.RunCustomAnalysis()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("RunCustomAnalysis deadlocked with MaxConcurrency=0")
+	}
+}
+
+// Test: RunCustomAnalysis must not panic when MaxConcurrency is negative.
+// make(chan struct{}, negative) previously panicked with "makechan: size out of range".
+func TestRunCustomAnalysisNegativeConcurrency(t *testing.T) {
+	viper.Set("custom_analyzers", []interface{}{})
+
+	analysisObj := &Analysis{
+		MaxConcurrency: -1,
+	}
+
+	require.NotPanics(t, func() {
+		analysisObj.RunCustomAnalysis()
+	})
 }
 
 // Test: Verbose output in GetAIResults


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- no issue filed yet; see the note under "Claiming" below -->


`RunCustomAnalysis` built its worker semaphore straight from the unvalidated
`a.MaxConcurrency` field:

```go
semaphore := make(chan struct{}, a.MaxConcurrency)
```

`RunAnalysis` does not do this: it clamps the value first. Because
`--max-concurrency` is a user-supplied flag (`cmd/analyze`, default 10, no
lower-bound validation), a non-positive value passed into custom analysis caused
two failures:

- `k8sgpt analyze --custom-analysis --max-concurrency 0` builds an unbuffered
  channel. The dispatch path does `semaphore <- struct{}{}` and only launches the
  draining goroutine on the next line, so the send blocks on a receiver that is
  never reached: the whole `analyze` command deadlocks whenever a custom analyzer
  is configured.
- `k8sgpt analyze --custom-analysis --max-concurrency -1` makes
  `make(chan struct{}, -1)` panic with `makechan: size out of range`, crashing the
  process (this path is reached even with zero custom analyzers, since the `make`
  precedes dispatch).

The fix applies the same lower/upper-bound clamp that `RunAnalysis` already uses
(default 10 for non-positive values, cap at 100) before creating the semaphore.
There is no behavior change for valid positive values in 1..100.

Regression tests cover both cases:
- `TestRunCustomAnalysisZeroConcurrency` runs `RunCustomAnalysis` in a goroutine
  guarded by a timeout and fails on deadlock.
- `TestRunCustomAnalysisNegativeConcurrency` asserts it does not panic.

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## Additional Information

The added clamp is a verbatim mirror of the block already present in `RunAnalysis`
(`pkg/analysis/analysis.go`), including the inline comments and the
`const maxAllowedConcurrency = 100`, so the two paths now behave identically for
out-of-range concurrency. No public API or flag default changes.

---

## Files changed

```
 pkg/analysis/analysis.go      | 11 ++++++++++-
 pkg/analysis/analysis_test.go | 43 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 53 insertions(+), 1 deletion(-)
```

- `pkg/analysis/analysis.go`: adds the 8-line concurrency clamp before the
  `semaphore := make(...)` in `RunCustomAnalysis` (mirrors `RunAnalysis`).
- `pkg/analysis/analysis_test.go`: adds `time` import + two regression tests.
