### PR TITLE
fix: use empty default for auth add --model so per-backend fallback runs

### DIFF
--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -165,7 +165,7 @@ func init() {
 	// add flag for backend
 	addCmd.Flags().StringVarP(&backend, "backend", "b", defaultBackend, "Backend AI provider")
 	// add flag for model
-	addCmd.Flags().StringVarP(&model, "model", "m", defaultModel, "Backend AI model")
+	addCmd.Flags().StringVarP(&model, "model", "m", "", "Backend AI model")
 	// add flag for password
 	addCmd.Flags().StringVarP(&password, "password", "p", "", "Backend AI password")
 	// add flag for url

--- a/cmd/auth/add.go
+++ b/cmd/auth/add.go
@@ -168,7 +168,7 @@ func init() {
 	// add flag for backend
 	addCmd.Flags().StringVarP(&backend, "backend", "b", defaultBackend, "Backend AI provider")
 	// add flag for model
-	addCmd.Flags().StringVarP(&model, "model", "m", defaultModel, "Backend AI model")
+	addCmd.Flags().StringVarP(&model, "model", "m", "", "Backend AI model")
 	// add flag for password
 	addCmd.Flags().StringVarP(&password, "password", "p", "", "Backend AI password")
 	// add flag for url

--- a/cmd/auth/provider_helpers_test.go
+++ b/cmd/auth/provider_helpers_test.go
@@ -141,6 +141,59 @@ func TestApplyAIProviderUpdatesIncludesAzureAPIVersion(t *testing.T) {
 	}
 }
 
+func TestAddCommandModelDefaultPerBackend(t *testing.T) {
+	tests := []struct {
+		name          string
+		backend       string
+		expectedModel string
+	}{
+		{
+			name:          "anthropic backend falls back to anthropic default model",
+			backend:       "anthropic",
+			expectedModel: anthropicDefaultModel,
+		},
+		{
+			name:          "openai backend falls back to openai default model",
+			backend:       "openai",
+			expectedModel: defaultModel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configureTestViper(t)
+			resetAuthFlagState(t)
+			configAI = ai.AIConfiguration{}
+
+			// Seed the model variable with the value cobra binds when --model is
+			// omitted (the flag's registered default). This reproduces a real
+			// `k8sgpt auth add -b <backend>` invocation without --model so the
+			// per-backend fallback in add.go is exercised.
+			model = addCmd.Flags().Lookup("model").DefValue
+
+			setFlag(t, addCmd, "backend", tt.backend)
+			setFlag(t, addCmd, "password", "token")
+			setFlag(t, addCmd, "temperature", "0.7")
+			setFlag(t, addCmd, "topp", "0.5")
+			setFlag(t, addCmd, "topk", "50")
+			setFlag(t, addCmd, "maxtokens", "2048")
+
+			addCmd.Run(addCmd, nil)
+
+			var cfg ai.AIConfiguration
+			if err := viper.UnmarshalKey("ai", &cfg); err != nil {
+				t.Fatalf("failed to unmarshal ai config: %v", err)
+			}
+			if len(cfg.Providers) != 1 {
+				t.Fatalf("expected one provider, got %d", len(cfg.Providers))
+			}
+			if cfg.Providers[0].Model != tt.expectedModel {
+				t.Fatalf("expected model %q for backend %q, got %q", tt.expectedModel, tt.backend, cfg.Providers[0].Model)
+			}
+		})
+	}
+}
+
 func resetAuthFlagState(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION

<!-- There is no upstream issue tracking this; the body self-describes the
regression instead of citing a fake issue number. -->
Closes # <!-- no tracking issue; this is a self-contained regression fix -->


`k8sgpt auth add -b anthropic`, run without `--model`, persists `model: gpt-4o`
for the Anthropic provider. The Anthropic API rejects `gpt-4o`, so the backend
does not work out of the box.

Root cause is a dead-code guard introduced with the Anthropic backend (#1652).
`cmd/auth/add.go` picks a per-backend default model only when the model is empty:

```go
// cmd/auth/add.go
if model == "" {
    fallbackModel := defaultModel
    if backend == "anthropic" {
        fallbackModel = anthropicDefaultModel // "claude-3-5-sonnet-latest"
    }
    model = fallbackModel
}
```

But the `--model` flag was registered with a **non-empty** default:

```go
addCmd.Flags().StringVarP(&model, "model", "m", defaultModel, "Backend AI model")
// defaultModel = "gpt-4o"
```

So when `--model` is omitted, cobra binds `model` to `"gpt-4o"`, the `model == ""`
guard never runs, and the Anthropic branch is unreachable. The client-side safety
net in `pkg/ai/anthropic.go` (`if model == "" { model = anthropicDefaultModel }`)
is also bypassed, because the persisted config already holds a non-empty `gpt-4o`.

### Fix

Register `--model` with an empty default, matching how `auth update` already does
it (`cmd/auth/update.go`). This lets the existing fallback resolve the correct
default per backend:

- `openai`  -> `gpt-4o`
- `anthropic` -> `claude-3-5-sonnet-latest`

`defaultModel` is still used as the OpenAI fallback inside the guard, so nothing
becomes unused.

```diff
-	addCmd.Flags().StringVarP(&model, "model", "m", defaultModel, "Backend AI model")
+	addCmd.Flags().StringVarP(&model, "model", "m", "", "Backend AI model")
```

Behavior when `--model` is passed explicitly is unchanged.

### Test

Adds `TestAddCommandModelDefaultPerBackend`, a table-driven test (anthropic +
openai) in `cmd/auth/provider_helpers_test.go`. It seeds `model` from the flag's
registered default to reproduce a real `auth add` without `--model`, then asserts
the persisted provider model. With the old non-empty default the anthropic case
fails (`got "gpt-4o"`); with the fix both cases pass. No cluster or API key
required.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
No breaking changes. Explicit `--model` values are unaffected; only the
omitted-`--model` default path changes, from always `gpt-4o` to the correct
per-backend default. Related prior art: #1603 (open) refactors this same block
into a `defaultModelForBackend` helper but keeps the unreachable guard; this fix
targets the flag registration (a different line), so the two do not conflict and
this change would make that helper reachable too.
