### PR TITLE
fix: guard against nil backend port in HTTPRoute analyzer

### DIFF
--- a/pkg/analyzer/httproute.go
+++ b/pkg/analyzer/httproute.go
@@ -177,6 +177,11 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						},
 					})
 				} else {
+					// Port is optional on a backendRef; skip the port check when
+					// it is unset rather than dereferencing a nil pointer.
+					if backend.Port == nil {
+						continue
+					}
 					portMatch := false
 					for _, svcPort := range service.Spec.Ports {
 						if int32(*backend.Port) == svcPort.Port {

--- a/pkg/analyzer/httproute_test.go
+++ b/pkg/analyzer/httproute_test.go
@@ -207,6 +207,73 @@ func TestGWConfigSameHTTRouteAnalyzer(t *testing.T) {
 		t.Errorf("Expected message, <%s> , not found in HTTPRoute's analysis results", want)
 	}
 }
+
+func TestSvcNilPortHTTRouteAnalyzer(t *testing.T) {
+	// Service the backendRef points to, so analysis reaches the port-match loop.
+	Service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foobackend",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": "example-app",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   "TCP",
+					Port:       80,
+					TargetPort: intstr.FromInt(8080),
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+	backendName := gtwapi.ObjectName("foobackend")
+	gtwName := gtwapi.ObjectName("gatewayname")
+	gtwNamespace := gtwapi.Namespace("default")
+	httpRouteNamespace := "default"
+
+	// backendRef with no Port set. Port is optional on BackendObjectReference,
+	// so a nil port must not panic the analyze run.
+	HTTPRoute := BuildHTTPRoute(backendName, gtwName, gtwNamespace, nil, httpRouteNamespace)
+
+	Gateway := BuildRouteGateway("default", "gatewayname", "Same")
+	// Create a Gateway Analyzer instance with the fake client
+	scheme := scheme.Scheme
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{
+		&HTTPRoute,
+		&Gateway,
+		&Service,
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := HTTPRouteAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	// A backendRef without a port must be skipped for the port check rather
+	// than dereferencing a nil pointer, so Analyze returns without panicking.
+	_, err = analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func TestGWConfigSelectorHTTRouteAnalyzer(t *testing.T) {
 	backendName := gtwapi.ObjectName("foobackend")
 	gtwName := gtwapi.ObjectName("gatewayname")


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #
<!-- No existing tracking issue: this is a self-found crash in the HTTPRoute
     analyzer. Leaving the Closes reference empty on purpose. -->


The HTTPRoute analyzer panics with a nil pointer dereference when a `backendRef`
omits its optional `port`.

While validating that each `backendRef` targets an existing Service on a matching
port, the analyzer dereferences `*backend.Port`:

```go
for _, svcPort := range service.Spec.Ports {
    if int32(*backend.Port) == svcPort.Port {
        portMatch = true
    }
}
```

`Port` is optional on a `BackendObjectReference` (`*gatewayv1.PortNumber`, marked
`+optional`), so it is `nil` whenever a backendRef leaves it unset, which is valid
and common. A single portless backendRef makes the whole `k8sgpt analyze` run
crash with a nil pointer dereference.

This adds an early `if backend.Port == nil { continue }` before the port-match
loop, so a backendRef without a port is skipped for the port check instead of
being dereferenced. That is consistent with how the other optional pointer
accesses in the Gateway analyzers are already guarded.

The change is a 5-line guard in `pkg/analyzer/httproute.go` plus a regression
test in `pkg/analyzer/httproute_test.go` (`TestSvcNilPortHTTRouteAnalyzer`) that
builds an HTTPRoute whose backendRef has a nil `Port` and asserts `Analyze`
returns without panicking. Reverting only the source guard makes the new test
panic, confirming it is a genuine regression test.

## Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## Additional Information

Same crash class as the previously merged Service `TargetRef` nil-guard
(#1672); this applies the same defensive fix to the HTTPRoute backendRef port
path. No behavior change for backendRefs that do set a port. No dependency or
API changes.
