### PR TITLE
fix: mask real pod name and namespace in statefulset analyzer

### DIFF
--- a/pkg/analyzer/statefulset.go
+++ b/pkg/analyzer/statefulset.go
@@ -116,11 +116,11 @@ func (StatefulSetAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						Text: fmt.Sprintf("Statefulset pod %s in the namespace %s is not in running state.", pod.Name, pod.Namespace),
 						Sensitive: []common.Sensitive{
 							{
-								Unmasked: sts.Namespace,
+								Unmasked: pod.Name,
 								Masked:   util.MaskString(pod.Name),
 							},
 							{
-								Unmasked: serviceName,
+								Unmasked: pod.Namespace,
 								Masked:   util.MaskString(pod.Namespace),
 							},
 						},

--- a/pkg/analyzer/statefulset_test.go
+++ b/pkg/analyzer/statefulset_test.go
@@ -15,10 +15,12 @@ package analyzer
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	"github.com/magiconair/properties/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -400,5 +402,81 @@ func TestStatefulSetAnalyzerUnavailableReplicaWithPodInitialized(t *testing.T) {
 	}
 	if !errorFound {
 		t.Errorf("Error expected: '%v', not found in StatefulSet's analysis results", want)
+	}
+}
+
+func TestStatefulSetAnalyzerNotRunningPodSensitiveMasking(t *testing.T) {
+	replicas := int32(3)
+	clientset := fake.NewSimpleClientset(
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: "default",
+			},
+			Spec: appsv1.StatefulSetSpec{
+				ServiceName: "example-svc",
+				Replicas:    &replicas,
+			},
+			Status: appsv1.StatefulSetStatus{
+				AvailableReplicas: 0,
+			},
+		},
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-svc",
+				Namespace: "default",
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-0",
+				Namespace: "default",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+			},
+		},
+	)
+	statefulSetAnalyzer := StatefulSetAnalyzer{}
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := statefulSetAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := "Statefulset pod example-0 in the namespace default is not in running state."
+
+	var failure *common.Failure
+	for i := range analysisResults {
+		for j := range analysisResults[i].Error {
+			if analysisResults[i].Error[j].Text == want {
+				failure = &analysisResults[i].Error[j]
+			}
+		}
+	}
+	if failure == nil {
+		t.Fatalf("Error expected: '%v', not found in StatefulSet's analysis results", want)
+	}
+
+	// Every Sensitive.Unmasked must be present in the failure text, otherwise it is
+	// never masked and the real value leaks to the LLM when --anonymize is used.
+	// Apply the same masking as analysis.GetAIResults and assert the raw pod name
+	// and namespace no longer appear.
+	masked := failure.Text
+	for _, s := range failure.Sensitive {
+		masked = util.ReplaceIfMatch(masked, s.Unmasked, s.Masked)
+	}
+	if strings.Contains(masked, "example-0") {
+		t.Errorf("pod name leaked after masking: %q still contains %q", masked, "example-0")
+	}
+	if strings.Contains(masked, "namespace default") {
+		t.Errorf("pod namespace leaked after masking: %q still contains %q", masked, "namespace default")
 	}
 }


### PR DESCRIPTION

<!-- No issue to close for this bug. -->


The StatefulSet analyzer leaks the real pod name to the LLM when `--anonymize`
is set, because two of its `Sensitive` entries reference the wrong fields.

In the "pod not running" failure, the text is built from `pod.Name` and
`pod.Namespace`:

```go
Text: fmt.Sprintf("Statefulset pod %s in the namespace %s is not in running state.", pod.Name, pod.Namespace),
```

but the `Sensitive` entries paired the wrong `Unmasked` values with the masks:

```go
{ Unmasked: sts.Namespace, Masked: util.MaskString(pod.Name) },
{ Unmasked: serviceName,   Masked: util.MaskString(pod.Namespace) },
```

Anonymization (`pkg/analysis/analysis.go`) replaces each `Unmasked` substring
found in the text via `util.ReplaceIfMatch(text, s.Unmasked, s.Masked)`. Since
neither `sts.Namespace` nor `serviceName` is the pod name that actually appears
in the text, the real pod name is never replaced and is sent to the LLM in the
clear; `serviceName` matches nothing at all. (The pod namespace only happens to
be masked when it equals the StatefulSet namespace, which is the common case,
so it is not reliably protected either.)

This sets each `Unmasked` to the field actually interpolated into the text, so
both the pod name and namespace are masked. This mirrors the already-correct
pattern used a few lines above in the same analyzer for the "service does not
exist" failure.

```go
{ Unmasked: pod.Name,      Masked: util.MaskString(pod.Name) },
{ Unmasked: pod.Namespace, Masked: util.MaskString(pod.Namespace) },
```

A regression test (`TestStatefulSetAnalyzerNotRunningPodSensitiveMasking`)
reproduces the analyzer output for a pending StatefulSet pod, applies the same
masking loop the analysis code uses, and asserts the raw pod name and namespace
do not survive. It fails on the old code (pod name leaks) and passes with the fix.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

No behavior change to analyzer output or messages; only the values masked under
`--anonymize` change. No API, dependency, or documentation changes.
