### PR TITLE
fix: return a fresh AI client per call to avoid shared-state data race

### DIFF
--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -19,24 +19,28 @@ import (
 )
 
 var (
-	clients = []IAI{
-		&OpenAIClient{},
-		&AnthropicClient{},
-		&AzureAIClient{},
-		&LocalAIClient{},
-		&OllamaClient{},
-		&NoOpAIClient{},
-		&CohereClient{},
-		&AmazonBedRockClient{},
-		&AmazonBedrockConverseClient{},
-		&SageMakerAIClient{},
-		&GoogleGenAIClient{},
-		&HuggingfaceClient{},
-		&GoogleVertexAIClient{},
-		&OCIGenAIClient{},
-		&CustomRestClient{},
-		&IBMWatsonxAIClient{},
-		&GroqClient{},
+	// clients maps each backend to a constructor that returns a fresh client.
+	// NewClient must hand back a new instance per call so that concurrent
+	// callers (e.g. server-mode Analyze requests) do not share and race on a
+	// single client's fields via Configure.
+	clients = []func() IAI{
+		func() IAI { return &OpenAIClient{} },
+		func() IAI { return &AnthropicClient{} },
+		func() IAI { return &AzureAIClient{} },
+		func() IAI { return &LocalAIClient{} },
+		func() IAI { return &OllamaClient{} },
+		func() IAI { return &NoOpAIClient{} },
+		func() IAI { return &CohereClient{} },
+		func() IAI { return &AmazonBedRockClient{} },
+		func() IAI { return &AmazonBedrockConverseClient{} },
+		func() IAI { return &SageMakerAIClient{} },
+		func() IAI { return &GoogleGenAIClient{} },
+		func() IAI { return &HuggingfaceClient{} },
+		func() IAI { return &GoogleVertexAIClient{} },
+		func() IAI { return &OCIGenAIClient{} },
+		func() IAI { return &CustomRestClient{} },
+		func() IAI { return &IBMWatsonxAIClient{} },
+		func() IAI { return &GroqClient{} },
 	}
 	Backends = []string{
 		openAIClientName,
@@ -99,8 +103,8 @@ type IAIConfig interface {
 }
 
 func NewClient(provider string) IAI {
-	for _, c := range clients {
-		if provider == c.GetName() {
+	for _, newClient := range clients {
+		if c := newClient(); provider == c.GetName() {
 			return c
 		}
 	}

--- a/pkg/ai/iai_test.go
+++ b/pkg/ai/iai_test.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package ai
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestAIProviderGetAzureAPIVersion(t *testing.T) {
 	provider := AIProvider{AzureAPIVersion: "2024-02-15-preview"}
@@ -21,4 +24,46 @@ func TestAIProviderGetAzureAPIVersion(t *testing.T) {
 	if got := provider.GetAzureAPIVersion(); got != "2024-02-15-preview" {
 		t.Fatalf("expected Azure API version to be returned, got %q", got)
 	}
+}
+
+// TestNewClientReturnsFreshInstance ensures NewClient hands back a new client on
+// every call rather than a shared package-level singleton. A shared instance
+// would let concurrent callers overwrite each other's configuration.
+func TestNewClientReturnsFreshInstance(t *testing.T) {
+	first := NewClient(openAIClientName)
+	second := NewClient(openAIClientName)
+
+	if first == second {
+		t.Fatalf("expected distinct clients per call, got the same instance %p", first)
+	}
+}
+
+// TestNewClientConcurrentConfigure runs concurrent Configure calls on clients
+// obtained from NewClient. Under the race detector this fails if NewClient
+// returns a shared instance whose fields are mutated by Configure. Run with:
+// go test -race ./pkg/ai/ -run TestNewClientConcurrentConfigure
+func TestNewClientConcurrentConfigure(t *testing.T) {
+	const goroutines = 8
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			provider := &AIProvider{
+				Model:       "model-" + string(rune('A'+id)),
+				Password:    "token-" + string(rune('A'+id)),
+				Temperature: float32(id),
+			}
+			for j := 0; j < iterations; j++ {
+				c := NewClient(openAIClientName)
+				if err := c.Configure(provider); err != nil {
+					t.Errorf("Configure failed: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION

```
Closes #<ISSUE>

## 📑 Description

`ai.NewClient` looked up the requested backend in a package-level slice of
pre-allocated client instances and returned that shared instance directly. Every
caller then configures it in place via `Configure` (for example
`OpenAIClient.Configure` sets `client`, `model`, `temperature` and `topP`).

Under the CLI this is harmless because analysis runs sequentially. In server mode
it is not: each gRPC/MCP Analyze request builds its own `analysis.Analysis`, and
grpc-go serves every RPC in its own goroutine with no serializing lock. Concurrent
requests for the same backend therefore race on the singleton's fields, and one
request can overwrite another's configuration (model, temperature, base URL, token,
custom headers), so a request may end up calling the model with another request's
settings.

This makes the `clients` registry a list of constructors and has `NewClient` invoke
the matching constructor, so every call returns a distinct client and each analysis
owns its own. Callers already treat the return value as their own, so no other code
changes are needed. `NewClient` still returns `IAI` and the default fallback still
returns a fresh `&OpenAIClient{}`, so the change is source-compatible.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Adds two regression tests in `pkg/ai/iai_test.go`:
`TestNewClientReturnsFreshInstance` (distinct instance per call) and
`TestNewClientConcurrentConfigure` (concurrent `Configure` calls, which trip the
race detector before this change and pass after).

Verified locally: `gofmt -l`, `go vet ./pkg/ai/...`, `go build ./...`,
`go test -race ./pkg/ai/`, and `go test ./pkg/analysis/... ./pkg/server/...` all
pass.
```

---

## Companion issue (open this FIRST, then put its number into `Closes #<ISSUE>`)

CONTRIBUTING asks contributors to discuss/track the work on an issue, and the PR
template wants `Closes #<id>`. There is no existing issue for this race, so open a
short bug report (same pattern as the merged nil-TargetRef fix, which paired a
2-line issue with the PR). If Anas would rather file PR-only, drop the `Closes`
line and paste the Description into the issueless body.

**Title:**
```
AI client is a shared singleton: concurrent server-mode Analyze requests race on its config
```

**Body:**
```
`ai.NewClient` (pkg/ai/iai.go) returns a shared, package-level client instance for
each backend rather than a fresh one. Callers immediately mutate that instance via
`Configure` (e.g. `OpenAIClient.Configure` sets client/model/temperature/topP).

In CLI use this is harmless because analysis is sequential. In server mode
(`k8sgpt serve`) each gRPC/MCP Analyze request builds its own analysis and grpc-go
runs each RPC in its own goroutine with no serializing lock, so concurrent requests
for the same backend race on the shared instance's fields and can overwrite one
another's configuration (model, temperature, base URL, token, custom headers). This
is both a data race (observable under `go test -race`) and a cross-request config
bleed.

Expected: `NewClient` should hand back a distinct client per call so each analysis
owns its own configuration.
```
