### PR TITLE
fix: register gateway-api scheme once to avoid concurrent map writes

### DIFF
--- a/pkg/analyzer/concurrent_scheme_test.go
+++ b/pkg/analyzer/concurrent_scheme_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gtwapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// TestGatewayAnalyzersConcurrentScheme guards against issue #1063: running the
+// gateway-api analyzers in parallel used to crash with "fatal error:
+// concurrent map writes" because each analyzer registered the gateway-api types
+// into the shared client scheme from inside Analyze(). The types are now
+// registered once when the client is built, so the analyzers can safely share a
+// single client across goroutines. Run with -race to catch a regression.
+func TestGatewayAnalyzersConcurrentScheme(t *testing.T) {
+	// The gateway-api types are registered on the scheme once, up front, the
+	// same way NewClient does it when the real client is constructed.
+	testScheme := scheme.Scheme
+	if err := gtwapi.Install(testScheme); err != nil {
+		t.Fatal(err)
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(testScheme).Build()
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzers := []common.IAnalyzer{
+		GatewayAnalyzer{},
+		GatewayClassAnalyzer{},
+		HTTPRouteAnalyzer{},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		for _, analyzer := range analyzers {
+			wg.Add(1)
+			go func(a common.IAnalyzer) {
+				defer wg.Done()
+				if _, err := a.Analyze(config); err != nil {
+					t.Errorf("Analyze returned an unexpected error: %v", err)
+				}
+			}(analyzer)
+		}
+	}
+	wg.Wait()
+}

--- a/pkg/analyzer/gateway.go
+++ b/pkg/analyzer/gateway.go
@@ -37,10 +37,6 @@ func (GatewayAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	gtwList := &gtwapi.GatewayList{}
 	gc := &gtwapi.GatewayClass{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
-	if err != nil {
-		return nil, err
-	}
 
 	labelSelector := util.LabelStrToSelector(a.LabelSelector)
 	if err := client.List(a.Context, gtwList, &ctrl.ListOptions{LabelSelector: labelSelector}); err != nil {

--- a/pkg/analyzer/gatewayclass.go
+++ b/pkg/analyzer/gatewayclass.go
@@ -35,10 +35,6 @@ func (GatewayClassAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 
 	gcList := &gtwapi.GatewayClassList{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
-	if err != nil {
-		return nil, err
-	}
 
 	labelSelector := util.LabelStrToSelector(a.LabelSelector)
 	if err := client.List(a.Context, gcList, &ctrl.ListOptions{LabelSelector: labelSelector}); err != nil {

--- a/pkg/analyzer/httproute.go
+++ b/pkg/analyzer/httproute.go
@@ -38,10 +38,6 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	gtw := &gtwapi.Gateway{}
 	service := &corev1.Service{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
-	if err != nil {
-		return nil, err
-	}
 
 	labelSelector := util.LabelStrToSelector(a.LabelSelector)
 	if err := client.List(a.Context, routeList, &ctrl.ListOptions{LabelSelector: labelSelector}); err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+	gtwapi "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 func (c *Client) GetConfig() *rest.Config {
@@ -66,6 +67,14 @@ func NewClient(kubecontext string, kubeconfig string) (*Client, error) {
 
 	ctrlClient, err := ctrl.New(config, ctrl.Options{})
 	if err != nil {
+		return nil, err
+	}
+
+	// Register the gateway-api types on the shared client scheme once, here,
+	// instead of inside each analyzer's Analyze(). The gateway analyzers run
+	// concurrently against this single client, and registering into the scheme
+	// on the hot path races on the scheme's internal maps (issue #1063).
+	if err := gtwapi.Install(ctrlClient.Scheme()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -23,6 +23,8 @@ import (
 	gtwapi "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+var installGatewayAPI = gtwapi.Install
+
 func (c *Client) GetConfig() *rest.Config {
 	return c.Config
 }
@@ -74,7 +76,7 @@ func NewClient(kubecontext string, kubeconfig string) (*Client, error) {
 	// instead of inside each analyzer's Analyze(). The gateway analyzers run
 	// concurrently against this single client, and registering into the scheme
 	// on the hot path races on the scheme's internal maps (issue #1063).
-	if err := gtwapi.Install(ctrlClient.Scheme()); err != nil {
+	if err := installGatewayAPI(ctrlClient.Scheme()); err != nil {
 		return nil, err
 	}
 

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -15,12 +15,14 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/tools/clientcmd"
@@ -55,4 +57,31 @@ func TestNewClientRegistersGatewayAPIScheme(t *testing.T) {
 		Version: gtwapi.GroupVersion.Version,
 		Kind:    "Gateway",
 	})
+}
+
+func TestNewClientReturnsGatewayAPIInstallError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(&version.Info{GitVersion: "v1.32.0"})
+	}))
+	t.Cleanup(server.Close)
+
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, clientcmd.WriteToFile(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {Server: server.URL},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {Cluster: "test"},
+		},
+		CurrentContext: "test",
+	}, kubeconfig))
+
+	sentinel := errors.New("gateway API install failed")
+	original := installGatewayAPI
+	installGatewayAPI = func(*runtime.Scheme) error { return sentinel }
+	t.Cleanup(func() { installGatewayAPI = original })
+
+	client, err := NewClient("", kubeconfig)
+	require.Nil(t, client)
+	require.ErrorIs(t, err, sentinel)
 }

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	gtwapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestNewClientRegistersGatewayAPIScheme(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(&version.Info{GitVersion: "v1.32.0"})
+	}))
+	t.Cleanup(server.Close)
+
+	kubeconfig := filepath.Join(t.TempDir(), "config")
+	require.NoError(t, clientcmd.WriteToFile(clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"test": {Server: server.URL},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"test": {Cluster: "test"},
+		},
+		CurrentContext: "test",
+	}, kubeconfig))
+
+	client, err := NewClient("", kubeconfig)
+	require.NoError(t, err)
+
+	kinds, _, err := client.CtrlClient.Scheme().ObjectKinds(&gtwapi.Gateway{})
+	require.NoError(t, err)
+	require.Contains(t, kinds, schema.GroupVersionKind{
+		Group:   gtwapi.GroupVersion.Group,
+		Version: gtwapi.GroupVersion.Version,
+		Kind:    "Gateway",
+	})
+}


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Refs #1063 (gateway-api facet; see note below)


The `Gateway`, `GatewayClass` and `HTTPRoute` analyzers each call
`gtwapi.AddToScheme(client.Scheme())` at the top of `Analyze()`:

```go
client := a.Client.CtrlClient
err := gtwapi.AddToScheme(client.Scheme())
if err != nil {
    return nil, err
}
```

`RunAnalysis` dispatches every analyzer in its own goroutine
(`go a.executeAnalyzer(...)`) against a single shared `CtrlClient`. The three
gateway-api analyzers therefore register the gateway-api types into the same
`runtime.Scheme` concurrently. `runtime.Scheme.AddKnownTypeWithName` writes its
internal maps without any lock, so this is a data race that Go turns into a hard
`fatal error: concurrent map writes`, taking down the whole process. In practice
`k8sgpt analyze` only completes reliably when a single run happens to serialize
these registrations, which is why users report it "only completes successfully
once" and then crashes on subsequent runs.

Fix: register the gateway-api types once, when the client is built in
`NewClient`, off the concurrent hot path, and drop the three per-`Analyze`
`AddToScheme` calls. The types are on the shared scheme before any analyzer runs,
so the goroutines only read the scheme and no longer race on it.

`gtwapi.Install` is used rather than the deprecated `gtwapi.AddToScheme`
(the latter is annotated `// Deprecated: use Install instead`); both resolve to
the same scheme builder, and `Install` is already the idiom used in the existing
gateway analyzer tests.

## Testing

Added `pkg/analyzer/concurrent_scheme_test.go`, which runs the three gateway-api
analyzers in parallel (50 iterations each) against one shared client, mirroring
how `RunAnalysis` fans out. It fails under `-race` on the old code with the
`concurrent map writes` / `DATA RACE` stack from #1063 and passes on this change.

Commands run locally (all pass):

```
gofmt -l <changed files>            # empty
go vet ./pkg/analyzer/... ./pkg/kubernetes/...
go build ./...
go test ./pkg/analyzer/... -race
go test ./pkg/kubernetes/... -race
go test ./...
```

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

#1063 is an umbrella "concurrent map writes" report that covers several distinct
analyzers. This PR fixes only the gateway-api facet (the `GatewayClassAnalyzer.
Analyze -> gateway-api addKnownTypes` stack shown in the issue), so it uses
`Refs #1063` rather than a closing keyword to avoid auto-closing the umbrella
while other facets remain. The trivy facet is already handled by the open
#1222; the external-secrets and kyverno facets are out of scope here and left
for follow-up PRs to keep this change small and focused.
