### PR TITLE
fix: populate ParentObject in ClusterCatalog and ClusterExtension analyzers

### DIFF
--- a/pkg/analyzer/clustercatalog.go
+++ b/pkg/analyzer/clustercatalog.go
@@ -82,7 +82,7 @@ func (ClusterCatalogAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error
 			Error: value.FailureDetails,
 		}
 
-		parent, found := util.GetParent(a.Client, value.Node.ObjectMeta)
+		parent, found := util.GetParent(a.Client, value.Catalog.ObjectMeta)
 		if found {
 			currentAnalysis.ParentObject = parent
 		}

--- a/pkg/analyzer/clustercatalog_test.go
+++ b/pkg/analyzer/clustercatalog_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -179,4 +181,78 @@ func TestClusterCatalogAnalyzer(t *testing.T) {
 	}
 	require.NoError(t, err)
 	require.Equal(t, 3, len(results))
+}
+
+// TestClusterCatalogAnalyzerParentObject ensures the analyzer resolves the
+// parent from the stored ClusterCatalog object. A previous copy-paste left it
+// reading value.Node.ObjectMeta, which is always empty for this analyzer, so
+// ParentObject was never populated.
+func TestClusterCatalogAnalyzerParentObject(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "olm.operatorframework.io",
+		Version:  "v1",
+		Resource: "clustercatalogs",
+	}
+
+	scheme := runtime.NewScheme()
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			gvr: "ClusterCatalogList",
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "olm.operatorframework.io/v1",
+				"kind":       "ClusterCatalog",
+				"metadata": map[string]interface{}{
+					"name": "ClusterCatalog with owner",
+					"ownerReferences": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"name":       "catalog-owner",
+						},
+					},
+				},
+				"spec": map[string]interface{}{
+					"availabilityMode": "Available",
+					"source": map[string]interface{}{
+						"type": "Image",
+						"image": map[string]interface{}{
+							"ref":                 "registry.redhat.io/redhat/community-operator-index:v4.19",
+							"pollIntervalMinutes": float64(10),
+						},
+					},
+				},
+				"status": map[string]interface{}{
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"type":   "Progressing",
+							"status": "True",
+							"reason": "Retrying",
+						},
+					},
+				},
+			},
+		},
+	)
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "catalog-owner",
+				},
+			}),
+			DynamicClient: dynamicClient,
+		},
+		Context:   context.Background(),
+		Namespace: "test",
+	}
+
+	ccAnalyzer := ClusterCatalogAnalyzer{}
+	results, err := ccAnalyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(results))
+	require.Equal(t, "Deployment/catalog-owner", results[0].ParentObject)
 }

--- a/pkg/analyzer/clusterextension.go
+++ b/pkg/analyzer/clusterextension.go
@@ -81,7 +81,7 @@ func (ClusterExtensionAnalyzer) Analyze(a common.Analyzer) ([]common.Result, err
 			Error: value.FailureDetails,
 		}
 
-		parent, found := util.GetParent(a.Client, value.Node.ObjectMeta)
+		parent, found := util.GetParent(a.Client, value.Extension.ObjectMeta)
 		if found {
 			currentAnalysis.ParentObject = parent
 		}

--- a/pkg/analyzer/clusterextension_test.go
+++ b/pkg/analyzer/clusterextension_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -176,4 +178,67 @@ func TestClusterExtensionAnalyzer(t *testing.T) {
 	}
 	require.NoError(t, err)
 	require.Equal(t, 2, len(results))
+}
+
+// TestClusterExtensionAnalyzerParentObject ensures the analyzer resolves the
+// parent from the stored ClusterExtension object. A previous copy-paste left it
+// reading value.Node.ObjectMeta, which is always empty for this analyzer, so
+// ParentObject was never populated.
+func TestClusterExtensionAnalyzerParentObject(t *testing.T) {
+	gvr := schema.GroupVersionResource{
+		Group:    "olm.operatorframework.io",
+		Version:  "v1",
+		Resource: "clusterextensions",
+	}
+
+	scheme := runtime.NewScheme()
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{
+			gvr: "ClusterExtensionList",
+		},
+		&unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "olm.operatorframework.io/v1",
+				"kind":       "ClusterExtension",
+				"metadata": map[string]interface{}{
+					"name": "Invalid UpgradeConstraintPolicy",
+					"ownerReferences": []interface{}{
+						map[string]interface{}{
+							"apiVersion": "apps/v1",
+							"kind":       "Deployment",
+							"name":       "extension-owner",
+						},
+					},
+				},
+				"spec": map[string]interface{}{
+					"source": map[string]interface{}{
+						"sourceType": "Catalog",
+						"catalog": map[string]interface{}{
+							"upgradeConstraintPolicy": "InvalidPolicy",
+						},
+					},
+				},
+			},
+		},
+	)
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "extension-owner",
+				},
+			}),
+			DynamicClient: dynamicClient,
+		},
+		Context:   context.Background(),
+		Namespace: "test",
+	}
+
+	ceAnalyzer := ClusterExtensionAnalyzer{}
+	results, err := ceAnalyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(results))
+	require.Equal(t, "Deployment/extension-owner", results[0].ParentObject)
 }


### PR DESCRIPTION

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- no matching open issue; see note below -->

## 📑 Description

The `ClusterCatalog` and `ClusterExtension` OLM analyzers never populate
`ParentObject` on their results.

Both analyzers store the object they are analyzing in `value.Catalog` /
`value.Extension`, but they look up the owning resource with:

```go
parent, found := util.GetParent(a.Client, value.Node.ObjectMeta)
```

`value.Node` is never set by these analyzers, so `GetParent` always ran against a
zero-value `ObjectMeta` (nil `OwnerReferences`), returned `("", false)`, and
`ParentObject` stayed empty. This is a copy-paste leftover from a Node-based
analyzer.

The fix reads the `ObjectMeta` from the field each analyzer actually stores,
matching every other analyzer in the package:

- `pkg/analyzer/clustercatalog.go`: `value.Node.ObjectMeta` -> `value.Catalog.ObjectMeta`
- `pkg/analyzer/clusterextension.go`: `value.Node.ObjectMeta` -> `value.Extension.ObjectMeta`

Each change also adds a focused regression test: a CR with an `ownerReferences`
entry pointing at a Deployment (seeded in the fake typed client) now asserts that
`ParentObject == "Deployment/<owner>"`. Both tests fail (`ParentObject == ""`)
without the one-line fix and pass with it.

This is the same class of fix as the previously merged #144 (`fix: ingress object
meta value`) and #1068 (`fix: invalid ParentObj in output`).

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

No behavior change beyond correctly resolving the parent object for these two
analyzers; no new dependencies. Verified locally:

- `gofmt -l` on the 4 changed files: clean
- `go vet ./pkg/analyzer/...`: clean
- `go build -o k8sgpt .`: ok
- `go test ./pkg/analyzer/... -count=1`: ok
- targeted: `go test ./pkg/analyzer/ -run 'TestClusterCatalogAnalyzerParentObject|TestClusterExtensionAnalyzerParentObject' -v`: both PASS
