### PR TITLE
fix: prevent nil prometheus config dereference on invalid gzipped config

### DIFF
--- a/pkg/integration/prometheus/config_analyzer.go
+++ b/pkg/integration/prometheus/config_analyzer.go
@@ -281,7 +281,7 @@ func unmarshalPromConfigBytes(b []byte) (*promconfig.Config, error) {
 		}
 		err = yaml.Unmarshal(gunzipBytes, &config)
 		if err != nil {
-			return nil, err
+			return &config, err
 		}
 		return &config, nil
 	} else {

--- a/pkg/integration/prometheus/config_analyzer_test.go
+++ b/pkg/integration/prometheus/config_analyzer_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prometheus
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// gzipBytes returns b compressed with gzip so that http.DetectContentType
+// classifies the result as "application/x-gzip".
+func gzipBytes(t *testing.T, b []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestUnmarshalPromConfigBytesGzipInvalid guards the contract that the helper
+// never returns a nil *Config. A payload that is detected as gzip but gunzips
+// to invalid YAML previously returned (nil, err), which made both analyzers
+// panic when they dereferenced config.ScrapeConfigs.
+func TestUnmarshalPromConfigBytesGzipInvalid(t *testing.T) {
+	// Invalid YAML for a Prometheus config (a bare scalar, not a mapping).
+	b := gzipBytes(t, []byte("::: not valid yaml :::"))
+
+	require.Equal(t, "application/x-gzip", http.DetectContentType(b),
+		"fixture must be detected as gzip to exercise the gunzip path")
+
+	config, err := unmarshalPromConfigBytes(b)
+	require.Error(t, err)
+	require.NotNil(t, config, "helper must never return a nil config")
+	// Reading ScrapeConfigs must be safe (this is the previously panicking deref).
+	require.Empty(t, config.ScrapeConfigs)
+}
+
+// TestPrometheusAnalyzersGzipInvalidConfig drives both Prometheus analyzers
+// end to end against a pod whose config volume holds a gzip-detected but
+// invalid Prometheus configuration. They must surface failures instead of
+// panicking.
+func TestPrometheusAnalyzersGzipInvalidConfig(t *testing.T) {
+	const (
+		namespace  = "monitoring"
+		configKey  = "prometheus.yaml"
+		volumeName = "config"
+		mountPath  = "/etc/prometheus"
+		configMap  = "prometheus-config"
+	)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-0",
+			Namespace: namespace,
+			Labels:    map[string]string{"app": "prometheus"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: configReloaderContainerName,
+					Args: []string{configReloaderConfigFlag + mountPath + "/" + configKey},
+					VolumeMounts: []corev1.VolumeMount{
+						{Name: volumeName, MountPath: mountPath},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: configMap},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMap,
+			Namespace: namespace,
+		},
+		// http.DetectContentType only inspects bytes, so gzip-detected but
+		// invalid YAML reaches the gunzip branch of unmarshalPromConfigBytes.
+		Data: map[string]string{
+			configKey: string(gzipBytes(t, []byte("::: not valid yaml :::"))),
+		},
+	}
+
+	newAnalyzer := func() common.Analyzer {
+		return common.Analyzer{
+			Client:    &kubernetes.Client{Client: fake.NewSimpleClientset(pod, cm)},
+			Context:   context.Background(),
+			Namespace: namespace,
+		}
+	}
+
+	t.Run("ConfigAnalyzer", func(t *testing.T) {
+		results, err := (&ConfigAnalyzer{}).Analyze(newAnalyzer())
+		require.NoError(t, err)
+		require.NotEmpty(t, results, "expected a validation failure for the invalid config")
+	})
+
+	t.Run("RelabelAnalyzer", func(t *testing.T) {
+		results, err := (&RelabelAnalyzer{}).Analyze(newAnalyzer())
+		require.NoError(t, err)
+		// No relabel report is expected; the point is that it does not panic.
+		require.Empty(t, results)
+	})
+}


### PR DESCRIPTION

<!-- No upstream issue; the "Closes #" line is intentionally omitted. -->


`unmarshalPromConfigBytes` in `pkg/integration/prometheus/config_analyzer.go`
could return a `nil` `*promconfig.Config` together with an error on one path:
when the input is detected as gzip (`http.DetectContentType(b) == "application/x-gzip"`),
gunzips successfully, but the inner `yaml.Unmarshal` fails. That single branch
returned `nil, err` while every other branch of the same function returns
`&config`.

Both callers then dereference the returned config without a nil check, so this
input crashes the process instead of surfacing a validation failure:

- `RelabelAnalyzer.Analyze` discards the error (`config, _ := unmarshalPromConfigBytes(pc.b)`)
  and immediately ranges `config.ScrapeConfigs`, panicking on the nil pointer.
- `ConfigAnalyzer.Analyze` records the error but does not `continue`, then reads
  `len(config.ScrapeConfigs)`, hitting the same nil-pointer dereference.

Since the analyzers deliberately route malformed configurations through this
helper to report validation failures, a corrupt or truncated gzip payload in a
Prometheus `ConfigMap`/`Secret` is a realistic trigger, and a hard panic is not
the intended outcome.

The fix makes the helper total: return the (empty) `&config` alongside the error
on that path, matching every other branch. Both analyzers then behave as
intended: `ConfigAnalyzer` surfaces the unmarshal error plus the empty
scrape-config failure, and `RelabelAnalyzer` ranges an empty slice without
panicking. Only the previously-panicking malformed-config path changes behavior.

## Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## Additional Information

- One-line production change (`config_analyzer.go`, the gunzip/invalid-YAML
  branch) plus a colocated `config_analyzer_test.go`.
- New tests:
  - `TestUnmarshalPromConfigBytesGzipInvalid` asserts the helper never returns a
    nil `*Config` on the gzip-detected/invalid-YAML path (the previously
    panicking dereference is now safe).
  - `TestPrometheusAnalyzersGzipInvalidConfig` drives both analyzers end to end
    with a fake clientset (a Prometheus pod plus a `ConfigMap` holding the
    gzip-detected invalid payload) and asserts they report failures without
    panicking.
- Verified red -> green: reverting the one-line change makes the helper test fail
  and `ConfigAnalyzer` panic with a nil-pointer dereference; with the change all
  tests pass.
- No breaking changes; no dependencies added.
