### PR TITLE
fix: harden analyzers, AI providers, server, and cache against panics and hangs

### DIFF
--- a/cmd/analyze/analyze.go
+++ b/cmd/analyze/analyze.go
@@ -176,5 +176,5 @@ func init() {
 	// label selector flag
 	AnalyzeCmd.Flags().StringVarP(&labelSelector, "selector", "L", "", "Label selector (label query) to filter on, supports '=', '==', and '!='. (e.g. -L key1=value1,key2=value2). Matching objects must satisfy all of the specified label constraints.")
 	// print stats
-	AnalyzeCmd.Flags().BoolVarP(&withStats, "with-stat", "s", false, "Print analysis stats. This option disables errors display.")
+	AnalyzeCmd.Flags().BoolVarP(&withStats, "with-stat", "s", false, "Print analysis stats (time taken per analyzer) in addition to the normal output.")
 }

--- a/pkg/ai/anthropic.go
+++ b/pkg/ai/anthropic.go
@@ -50,16 +50,16 @@ func (c *AnthropicClient) Configure(config IAIConfig) error {
 		opts = append(opts, option.WithAPIKey(token))
 	}
 
+	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
 	proxyEndpoint := config.GetProxyEndpoint()
 	if proxyEndpoint != "" {
 		proxyURL, err := url.Parse(proxyEndpoint)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, option.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
-		}))
+		httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
 	}
+	opts = append(opts, option.WithHTTPClient(httpClient))
 
 	model := config.GetModel()
 	if model == "" {

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -58,6 +58,7 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 			Proxy: http.ProxyFromEnvironment,
 		}
 		defaultConfig.HTTPClient = &http.Client{
+			Timeout: defaultHTTPTimeout,
 			Transport: &customHeaderRoundTripper{
 				headers: customHeaders,
 				rt:      transport,
@@ -73,6 +74,7 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 		}
 
 		defaultConfig.HTTPClient = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}
@@ -116,6 +118,9 @@ func (c *AzureAIClient) GetCompletion(ctx context.Context, prompt string) (strin
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }

--- a/pkg/ai/customrest.go
+++ b/pkg/ai/customrest.go
@@ -60,7 +60,7 @@ func (c *CustomRestClient) Configure(config IAIConfig) error {
 	c.base = baseClientURL
 
 	proxyEndpoint := config.GetProxyEndpoint()
-	c.client = http.DefaultClient
+	c.client = &http.Client{Timeout: defaultHTTPTimeout}
 	if proxyEndpoint != "" {
 		proxyUrl, err := url.Parse(proxyEndpoint)
 		if err != nil {
@@ -71,6 +71,7 @@ func (c *CustomRestClient) Configure(config IAIConfig) error {
 		}
 
 		c.client = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}

--- a/pkg/ai/groq.go
+++ b/pkg/ai/groq.go
@@ -59,6 +59,7 @@ func (c *GroqClient) Configure(config IAIConfig) error {
 
 	customHeaders := config.GetCustomHeaders()
 	defaultConfig.HTTPClient = &http.Client{
+		Timeout: defaultHTTPTimeout,
 		Transport: &OpenAIHeaderTransport{
 			Origin:  transport,
 			Headers: customHeaders,
@@ -93,6 +94,9 @@ func (c *GroqClient) GetCompletion(ctx context.Context, prompt string) (string, 
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -16,7 +16,17 @@ package ai
 import (
 	"context"
 	"net/http"
+	"time"
 )
+
+// defaultHTTPTimeout bounds the worst-case duration of a single AI backend
+// HTTP call. It acts as a safety net for backends whose SDK does not
+// propagate the request context's deadline all the way to the transport,
+// and for callers that pass a context with no deadline of its own. It is
+// intentionally generous (rather than a strict SLA) since local/self-hosted
+// backends such as Ollama can legitimately take minutes to generate a
+// completion on constrained hardware.
+const defaultHTTPTimeout = 10 * time.Minute
 
 var (
 	clients = []IAI{

--- a/pkg/ai/ollama.go
+++ b/pkg/ai/ollama.go
@@ -49,7 +49,7 @@ func (c *OllamaClient) Configure(config IAIConfig) error {
 	}
 
 	proxyEndpoint := config.GetProxyEndpoint()
-	httpClient := http.DefaultClient
+	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
 	if proxyEndpoint != "" {
 		proxyUrl, err := url.Parse(proxyEndpoint)
 		if err != nil {
@@ -60,6 +60,7 @@ func (c *OllamaClient) Configure(config IAIConfig) error {
 		}
 
 		httpClient = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -67,6 +67,7 @@ func (c *OpenAIClient) Configure(config IAIConfig) error {
 
 	customHeaders := config.GetCustomHeaders()
 	defaultConfig.HTTPClient = &http.Client{
+		Timeout: defaultHTTPTimeout,
 		Transport: &OpenAIHeaderTransport{
 			Origin:  transport,
 			Headers: customHeaders,
@@ -102,6 +103,9 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -329,6 +329,16 @@ func (a *Analysis) RunCustomAnalysis() {
 }
 
 func (a *Analysis) RunAnalysis() {
+	// Validate namespace if specified; otherwise a typo'd namespace silently
+	// yields empty results from every analyzer, misreporting a clean cluster.
+	if a.Namespace != "" && a.Client != nil {
+		_, err := a.Client.Client.CoreV1().Namespaces().Get(a.Context, a.Namespace, metav1.GetOptions{})
+		if err != nil {
+			a.Errors = append(a.Errors, fmt.Sprintf("namespace %q not found: %s", a.Namespace, err))
+			return
+		}
+	}
+
 	activeFilters := viper.GetStringSlice("active_filters")
 	verbose := viper.GetBool("verbose")
 

--- a/pkg/analysis/analysis_test.go
+++ b/pkg/analysis/analysis_test.go
@@ -47,6 +47,11 @@ func getTypeName(i interface{}) string {
 // helper function: run analysis with filter
 func analysis_RunAnalysisFilterTester(t *testing.T, filterFlag string) []common.Result {
 	clientset := fake.NewSimpleClientset(
+		&v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "default",
+			},
+		},
 		&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example",

--- a/pkg/analyzer/daemonset.go
+++ b/pkg/analyzer/daemonset.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -56,7 +55,7 @@ func (DaemonSetAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			})
 		}
 		for _, imagePullSecret := range ds.Spec.Template.Spec.ImagePullSecrets {
-			_, err := a.Client.GetClient().CoreV1().Secrets(ds.Namespace).Get(context.Background(), imagePullSecret.Name, metav1.GetOptions{})
+			_, err := a.Client.GetClient().CoreV1().Secrets(ds.Namespace).Get(a.Context, imagePullSecret.Name, metav1.GetOptions{})
 			if err != nil {
 				failures = append(failures, common.Failure{
 					Text: fmt.Sprintf("DaemonSet %s/%s references non-existent ImagePullSecret %s", ds.Namespace, ds.Name, imagePullSecret.Name),

--- a/pkg/analyzer/deployment.go
+++ b/pkg/analyzer/deployment.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func (d DeploymentAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 		"analyzer_name": kind,
 	})
 
-	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/ingress.go
+++ b/pkg/analyzer/ingress.go
@@ -105,6 +105,10 @@ func (IngressAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			// loop over HTTP paths
 			if rule.HTTP != nil {
 				for _, path := range rule.HTTP.Paths {
+					if path.Backend.Service == nil {
+						// Backend uses a custom resource (e.g. path.Backend.Resource) instead of a Service; nothing to validate here.
+						continue
+					}
 					_, err := a.Client.GetClient().CoreV1().Services(ing.Namespace).Get(a.Context, path.Backend.Service.Name, metav1.GetOptions{})
 					if err != nil {
 						doc := apiDoc.GetApiDocV2("spec.rules.http.paths.backend.service")

--- a/pkg/analyzer/mutating_webhook.go
+++ b/pkg/analyzer/mutating_webhook.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -42,7 +41,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 		"analyzer_name": kind,
 	})
 
-	mutatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	mutatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().MutatingWebhookConfigurations().List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 			}
 			svc := webhook.ClientConfig.Service
 			// Get the service
-			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, v1.GetOptions{})
+			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(a.Context, svc.Name, v1.GetOptions{})
 			if err != nil {
 				// If the service is not found, we can't check the pods
 				failures = append(failures, common.Failure{
@@ -88,7 +87,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 				continue
 			}
 			// Get pods within service
-			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
+			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(a.Context, v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),
 			})
 			if err != nil {

--- a/pkg/analyzer/validating_webhook.go
+++ b/pkg/analyzer/validating_webhook.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -42,7 +41,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 		"analyzer_name": kind,
 	})
 
-	validatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	validatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +55,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 			}
 			svc := webhook.ClientConfig.Service
 			// Get the service
-			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, v1.GetOptions{})
+			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(a.Context, svc.Name, v1.GetOptions{})
 			if err != nil {
 				// If the service is not found, we can't check the pods
 				failures = append(failures, common.Failure{
@@ -86,7 +85,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 				continue
 			}
 			// Get pods within service
-			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
+			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(a.Context, v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),
 			})
 			if err != nil {

--- a/pkg/cache/file_based.go
+++ b/pkg/cache/file_based.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
@@ -13,6 +14,27 @@ var _ (ICache) = (*FileBasedCache)(nil)
 
 type FileBasedCache struct {
 	noCache bool
+}
+
+// cachePath resolves key to a path inside the k8sgpt cache directory,
+// rejecting keys (e.g. containing "..") that would otherwise let a caller
+// escape that directory via path traversal.
+func cachePath(key string) (string, error) {
+	baseDir, err := xdg.CacheFile("k8sgpt")
+	if err != nil {
+		return "", err
+	}
+
+	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	if err != nil {
+		return "", err
+	}
+
+	if path != baseDir && !strings.HasPrefix(path, baseDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid cache key %q: resolves outside the cache directory", key)
+	}
+
+	return path, nil
 }
 
 func (f *FileBasedCache) Configure(cacheInfo CacheProvider) error {
@@ -50,7 +72,7 @@ func (*FileBasedCache) List() ([]CacheObjectDetails, error) {
 }
 
 func (*FileBasedCache) Exists(key string) bool {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "warning: error while testing if cache key exists:", err)
@@ -68,7 +90,7 @@ func (*FileBasedCache) Exists(key string) bool {
 }
 
 func (*FileBasedCache) Load(key string) (string, error) {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return "", err
@@ -84,7 +106,7 @@ func (*FileBasedCache) Load(key string) (string, error) {
 }
 
 func (*FileBasedCache) Remove(key string) error {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return err
@@ -98,7 +120,7 @@ func (*FileBasedCache) Remove(key string) error {
 }
 
 func (*FileBasedCache) Store(key string, data string) error {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return err

--- a/pkg/server/config/handler.go
+++ b/pkg/server/config/handler.go
@@ -4,13 +4,27 @@ import (
 	rpc "buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc"
 	schemav1 "buf.build/gen/go/k8sgpt-ai/k8sgpt/protocolbuffers/go/schema/v1"
 	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type Handler struct {
 	rpc.UnimplementedServerConfigServiceServer
+	// ShutdownFunc, when set, is invoked to gracefully stop the server in
+	// response to a Shutdown RPC. It is injected by the server package,
+	// which owns the listener lifecycle.
+	ShutdownFunc func() error
 }
 
 func (h *Handler) Shutdown(ctx context.Context, request *schemav1.ShutdownRequest) (*schemav1.ShutdownResponse, error) {
-	//TODO implement me
-	panic("implement me")
+	if h.ShutdownFunc == nil {
+		return nil, status.Error(codes.Unimplemented, "shutdown is not supported by this server instance")
+	}
+	// Run asynchronously: shutting down closes the listener the current RPC
+	// is being served on, so it must not block the response to this call.
+	go func() {
+		_ = h.ShutdownFunc()
+	}()
+	return &schemav1.ShutdownResponse{Status: "shutting down"}, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -101,10 +101,10 @@ func (s *Config) Serve() error {
 		return err
 	}
 
-	s.ConfigHandler = &config.Handler{}
+	s.listener = lis
+	s.ConfigHandler = &config.Handler{ShutdownFunc: s.Shutdown}
 	s.AnalyzeHandler = &analyze.Handler{}
 	s.QueryHandler = &query.Handler{}
-	s.listener = lis
 	s.Logger.Info(fmt.Sprintf("binding api to %s", s.Port))
 	grpcServerUnaryInterceptor := grpc.UnaryInterceptor(LogInterceptor(s.Logger))
 	grpcServer := grpc.NewServer(grpcServerUnaryInterceptor)


### PR DESCRIPTION
## 📑 Description

A small sweep of bug fixes found while reading through the analyzer, AI provider, server, and cache packages. Each fix is an independent commit so they can be reviewed and reverted individually if needed.

- **`fix(analyzer)`**: the Ingress analyzer dereferenced `path.Backend.Service` unconditionally, panicking on any Ingress using a `resource` backend instead of a `service` backend (e.g. S3 or custom controller backends).
- **`fix(server)`**: the `Shutdown` gRPC handler was a stub that called `panic("implement me")`. Since reflection is enabled and the endpoint has no auth, any client could crash a running `k8sgpt serve` process with a single call. It now gracefully closes the listener instead.
- **`fix(ai)`**: the OpenAI, Azure OpenAI, and Groq clients indexed `resp.Choices[0]` without checking the slice was non-empty, panicking on a content-filtered/empty completion. Also added a default HTTP client timeout across the OpenAI-compatible, custom REST, Ollama, and Anthropic clients, since none had one and a hung endpoint could block `analyze --explain` indefinitely.
- **`fix(analysis)`**: `RunAnalysis` didn't validate that `--namespace` exists before running (unlike `RunCustomAnalysis`, which already does). A typo'd namespace silently reported "No problems detected" instead of an error.
- **`fix(analyzer)`**: the Deployment, DaemonSet, and Mutating/ValidatingWebhook analyzers called the Kubernetes API with `context.Background()` instead of the caller-supplied `a.Context`, unlike every other analyzer in the package.
- **`fix(cli)`**: corrected the `--with-stat` flag description, which claimed it disables error display — it doesn't; stats are printed in addition to normal output.
- **`fix(cache)`**: the file-based cache built file paths by joining the cache directory with a caller-supplied key without checking the result stayed inside that directory, allowing a key like `../../some-file` to resolve outside the cache subdirectory.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
No behavior changes beyond the bug fixes described above. `go build ./...`, `go vet ./...`, and the full test suite pass locally. One existing test (`TestAnalysis_RunAnalysisWithFilter`) needed a `Namespace` fixture added to its fake clientset, since it started exercising the new namespace-validation path.
