### PR TITLE
fix: only report a missing IngressClass on an actual NotFound

### DIFF
--- a/pkg/analyzer/ingress.go
+++ b/pkg/analyzer/ingress.go
@@ -19,6 +19,7 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -83,7 +84,12 @@ func (IngressAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			// an IngressClass resource (they are recognized by the GKE ingress controller)
 			if !isGKEBuiltInIngressClass(*ingressClassName) {
 				_, err := a.Client.GetClient().NetworkingV1().IngressClasses().Get(a.Context, *ingressClassName, metav1.GetOptions{})
-				if err != nil {
+				// Only report a missing class on an actual NotFound. Any other
+				// error (RBAC forbidden — e.g. a service account without
+				// cluster-scoped ingressclasses access — or a transient API
+				// failure) means the class could not be verified, and reporting
+				// it as non-existent would be a false positive (#1668).
+				if apierrors.IsNotFound(err) {
 					doc := apiDoc.GetApiDocV2("spec.ingressClassName")
 
 					failures = append(failures, common.Failure{

--- a/pkg/analyzer/ingress_test.go
+++ b/pkg/analyzer/ingress_test.go
@@ -15,6 +15,7 @@ package analyzer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -22,8 +23,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 func TestIngressAnalyzer(t *testing.T) {
@@ -422,6 +427,70 @@ func TestIngressAnalyzerGKEIngressClass(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIngressAnalyzerIngressClassVerification(t *testing.T) {
+	className := "alb"
+
+	ingressWithClass := func(name string) *networkingv1.Ingress {
+		return &networkingv1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+			},
+			Spec: networkingv1.IngressSpec{
+				IngressClassName: &className,
+			},
+		}
+	}
+
+	t.Run("existing ingress class reports no failure", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(
+			&networkingv1.IngressClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: className,
+				},
+			},
+			ingressWithClass("alb-ingress"),
+		)
+
+		config := common.Analyzer{
+			Client: &kubernetes.Client{
+				Client: clientset,
+			},
+			Context:   context.Background(),
+			Namespace: "default",
+		}
+
+		analyzer := IngressAnalyzer{}
+		results, err := analyzer.Analyze(config)
+		require.NoError(t, err)
+		assert.Empty(t, results, "Expected no errors when the ingress class exists")
+	})
+
+	t.Run("forbidden ingress class lookup is not reported as missing", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset(ingressWithClass("alb-ingress"))
+		clientset.PrependReactor("get", "ingressclasses", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, apierrors.NewForbidden(
+				schema.GroupResource{Group: "networking.k8s.io", Resource: "ingressclasses"},
+				className,
+				fmt.Errorf("no cluster-scoped ingressclasses access"),
+			)
+		})
+
+		config := common.Analyzer{
+			Client: &kubernetes.Client{
+				Client: clientset,
+			},
+			Context:   context.Background(),
+			Namespace: "default",
+		}
+
+		analyzer := IngressAnalyzer{}
+		results, err := analyzer.Analyze(config)
+		require.NoError(t, err)
+		assert.Empty(t, results, "Expected no errors when the class lookup fails for a reason other than NotFound")
+	})
 }
 
 // Helper functions


### PR DESCRIPTION
## 📑 Description

Closes #1668.

@radiansatria reported the Ingress analyzer firing *"Ingress uses the ingress class alb which does not exist"* on EKS clusters where the AWS Load Balancer Controller's `alb` IngressClass is demonstrably present. #1599 worked around the same symptom for GKE by allowlisting `gce`/`gce-internal` by name, but name allowlists don't generalise across cloud providers.

**Root cause:** the analyzer treats *every* error from `IngressClasses().Get(...)` as "class does not exist". The reporter sees the false positive via operator Result CRs, and the k8sgpt-operator's service-account role grants no cluster-scoped `ingressclasses` access (the word doesn't appear anywhere in that repo) — so on operator deployments the Get fails **Forbidden** for every class, real or not, and the analyzer mislabels it "missing". Any transient API error does the same.

**Fix:** only `apierrors.IsNotFound` produces the "does not exist" failure. Any other error means the class simply couldn't be verified, so no failure is emitted. The GKE allowlist stays: those built-in classes are valid *without* an IngressClass resource, so NotFound is legitimately expected for them.

Also worth doing as a follow-up (separate repo): grant the operator role `get` on `networking.k8s.io/ingressclasses`, which restores real verification on operator deployments instead of skipping it.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

`go test ./pkg/analyzer/` is green, including two new regression tests: an existing class produces no failure, and a Forbidden class lookup is no longer reported as missing.

🤝 _Opened by Alex's [Repo Steward](https://github.com/AlexsJones/repo-steward) — replies reviewed by [@AlexsJones](https://github.com/AlexsJones)._

Learn more or run your own: https://github.com/AlexsJones/repo-steward
