### PR TITLE
fix: skip succeeded pods to stop false positives on completed jobs

### DIFF
--- a/pkg/analyzer/pod.go
+++ b/pkg/analyzer/pod.go
@@ -45,6 +45,13 @@ func (PodAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	for _, pod := range list.Items {
 		var failures []common.Failure
 
+		// Skip succeeded pods: the pod completed on purpose, and any non-zero
+		// exit code left in a container status (e.g. a sidecar killed at job
+		// completion) is not a failure.
+		if pod.Status.Phase == v1.PodSucceeded {
+			continue
+		}
+
 		// Check for pending pods
 		if pod.Status.Phase == "Pending" {
 			// Check through container status to check for crashes

--- a/pkg/analyzer/pod_test.go
+++ b/pkg/analyzer/pod_test.go
@@ -514,6 +514,73 @@ func TestPodAnalyzer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Succeeded pod with a non-zero container exit code is not reported",
+			config: common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: fake.NewSimpleClientset(
+						&v1.Pod{
+							// Completed on purpose; the leftover exit code 255
+							// (e.g. a sidecar killed at job completion) must not
+							// be reported as a failure.
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "Pod1",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Phase: v1.PodSucceeded,
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										Name:  "Container1",
+										Ready: false,
+										State: v1.ContainerState{
+											Terminated: &v1.ContainerStateTerminated{
+												ExitCode: 255,
+												Reason:   "Error",
+											},
+										},
+									},
+								},
+							},
+						},
+						&v1.Pod{
+							// A genuinely failed pod in the same namespace is
+							// still reported.
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "Pod2",
+								Namespace: "default",
+							},
+							Status: v1.PodStatus{
+								Phase: v1.PodFailed,
+								ContainerStatuses: []v1.ContainerStatus{
+									{
+										Name:  "Container1",
+										Ready: false,
+										State: v1.ContainerState{
+											Terminated: &v1.ContainerStateTerminated{
+												ExitCode: 1,
+												Reason:   "Error",
+											},
+										},
+									},
+								},
+							},
+						},
+					),
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			},
+			expectations: []struct {
+				name          string
+				failuresCount int
+			}{
+				{
+					name:          "default/Pod2",
+					failuresCount: 1,
+				},
+			},
+		},
 	}
 
 	podAnalyzer := PodAnalyzer{}


### PR DESCRIPTION
## What this does

The pod analyzer reports any terminated container with a non-zero exit code, even when the pod's phase is `Succeeded`. A completed job pod can legitimately carry a non-zero code in a container status (a sidecar killed at completion is the common case), so `k8sgpt analyze` flags healthy, finished pods as problems.

This adds a phase guard at the top of the pod loop: `Succeeded` pods are skipped before any container-status analysis. Regression test included: a `Succeeded` pod with `exitCode=255` produces no result, while a `Failed` pod in the same namespace is still reported.

Fixes #1581

## Credit

The diagnosis (succeeded pods slipping through the exit-code check) comes from @octo-patch's investigation on #1581 and their PR #1639, which is stalled on an unsigned EasyCLA. This is an independent reimplementation of the concept, not a copy of that patch, so it carries no CLA encumbrance. Thank you @octo-patch, the root-cause work here was yours.

## Testing

- `go test ./pkg/analyzer/` passes, including the new regression case.
