### PR TITLE
fix: ignore HPA ScalingLimited TooFewReplicas at minReplicas

### DIFF
--- a/pkg/analyzer/hpa.go
+++ b/pkg/analyzer/hpa.go
@@ -26,6 +26,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// scalingLimitedTooFewReplicas is the reason the HPA controller sets on the
+// ScalingLimited condition when the raw replica calculation is below
+// spec.minReplicas. Kubernetes does not export these reason strings, so the
+// value is mirrored here.
+const scalingLimitedTooFewReplicas = "TooFewReplicas"
+
 type HpaAnalyzer struct{}
 
 func (HpaAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
@@ -60,12 +66,21 @@ func (HpaAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			// https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#appendix-horizontal-pod-autoscaler-status-conditions
 			switch condition.Type {
 			case autoscalingv2.ScalingLimited:
-				if condition.Status == corev1.ConditionTrue {
-					failures = append(failures, common.Failure{
-						Text:      condition.Message,
-						Sensitive: []common.Sensitive{},
-					})
+				if condition.Status != corev1.ConditionTrue {
+					break
 				}
+				// An HPA sitting at its minimum replica count always reports
+				// ScalingLimited=True with reason TooFewReplicas. That is the
+				// replica floor working as designed, not a fault.
+				atMinReplicas := hpa.Spec.MinReplicas != nil &&
+					hpa.Status.DesiredReplicas == *hpa.Spec.MinReplicas
+				if condition.Reason == scalingLimitedTooFewReplicas && atMinReplicas {
+					break
+				}
+				failures = append(failures, common.Failure{
+					Text:      condition.Message,
+					Sensitive: []common.Sensitive{},
+				})
 			default:
 				if condition.Status == corev1.ConditionFalse {
 					failures = append(failures, common.Failure{

--- a/pkg/analyzer/hpa_test.go
+++ b/pkg/analyzer/hpa_test.go
@@ -819,3 +819,77 @@ func TestHPAAnalyzerStatusScalingLimitedError(t *testing.T) {
 		t.Errorf("Expected message, <%v> , not found in HorizontalPodAutoscaler's analysis results", want)
 	}
 }
+
+func TestHPAAnalyzerScalingLimitedTooFewReplicasAtMinIgnored(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "example",
+				},
+				MinReplicas: func() *int32 { i := int32(2); return &i }(),
+				MaxReplicas: 6,
+			},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				CurrentReplicas: 2,
+				DesiredReplicas: 2,
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{
+						Type:    autoscalingv2.ScalingLimited,
+						Status:  corev1.ConditionTrue,
+						Reason:  "TooFewReplicas",
+						Message: "the desired replica count is less than the minimum replica count",
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "example",
+								Image: "nginx",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("100m"),
+										"memory": resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse("200m"),
+										"memory": resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
+}

--- a/pkg/analyzer/hpa_test.go
+++ b/pkg/analyzer/hpa_test.go
@@ -893,3 +893,155 @@ func TestHPAAnalyzerScalingLimitedTooFewReplicasAtMinIgnored(t *testing.T) {
 	}
 	assert.Equal(t, len(analysisResults), 0)
 }
+
+func TestHPAAnalyzerScalingLimitedTooFewReplicasAboveMinReported(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "example",
+				},
+				MinReplicas: func() *int32 { i := int32(2); return &i }(),
+				MaxReplicas: 6,
+			},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				CurrentReplicas: 5,
+				DesiredReplicas: 5,
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{
+						Type:    autoscalingv2.ScalingLimited,
+						Status:  corev1.ConditionTrue,
+						Reason:  "TooFewReplicas",
+						Message: "the desired replica count is less than the minimum replica count",
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "example",
+								Image: "nginx",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("100m"),
+										"memory": resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse("200m"),
+										"memory": resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+	assert.Equal(t, len(analysisResults[0].Error), 1)
+	assert.Equal(t, analysisResults[0].Error[0].Text, "the desired replica count is less than the minimum replica count")
+}
+
+func TestHPAAnalyzerScalingLimitedTooManyReplicasReported(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+					Kind: "Deployment",
+					Name: "example",
+				},
+				MinReplicas: func() *int32 { i := int32(2); return &i }(),
+				MaxReplicas: 2,
+			},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				CurrentReplicas: 2,
+				DesiredReplicas: 2,
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{
+					{
+						Type:    autoscalingv2.ScalingLimited,
+						Status:  corev1.ConditionTrue,
+						Reason:  "TooManyReplicas",
+						Message: "the desired replica count is more than the maximum replica count",
+					},
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "example",
+				Namespace:   "default",
+				Annotations: map[string]string{},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "example",
+								Image: "nginx",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										"cpu":    resource.MustParse("100m"),
+										"memory": resource.MustParse("128Mi"),
+									},
+									Limits: corev1.ResourceList{
+										"cpu":    resource.MustParse("200m"),
+										"memory": resource.MustParse("256Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+	hpaAnalyzer := HpaAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := hpaAnalyzer.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+	assert.Equal(t, len(analysisResults[0].Error), 1)
+	assert.Equal(t, analysisResults[0].Error[0].Text, "the desired replica count is more than the maximum replica count")
+}


### PR DESCRIPTION
Closes #1667

## 📑 Description

The HPA analyzer inspected only `condition.Status` on the `ScalingLimited` condition. The Kubernetes HPA controller sets `ScalingLimited=True` with `reason=TooFewReplicas` on every HPA whose raw replica calculation falls below `spec.minReplicas` — the normal state for an idle HPA resting on its floor — so healthy autoscalers were reported as failures. Under the k8sgpt-operator this produced a Result CR and downstream alerts on every reconcile.

This reads `condition.Reason` and skips the failure only when the reason is `TooFewReplicas` and `status.desiredReplicas` equals `spec.minReplicas`. The comparison is nil-safe: an HPA with no `minReplicas` set keeps reporting.

`TooManyReplicas` deliberately keeps reporting. Hitting the ceiling can indicate genuine saturation, so suppressing it seemed riskier than the floor case. Happy to widen the scope if you would rather see all routine reasons handled at once.

Tests added:

- `TestHPAAnalyzerScalingLimitedTooFewReplicasAtMinIgnored` — HPA idling at `minReplicas` produces no result.
- `TestHPAAnalyzerScalingLimitedTooFewReplicasAboveMinReported` — `TooFewReplicas` with `desiredReplicas` above the floor still reports.
- `TestHPAAnalyzerScalingLimitedTooManyReplicasReported` — `TooManyReplicas` still reports.

The existing `TestHPAAnalyzerStatusField` and `TestHPAAnalyzerStatusScalingLimitedError` are unchanged and still pass: both leave `Reason` empty, so they fall outside the new skip.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Behavior change for users who relied on the previous output: an HPA at its replica floor no longer appears in `k8sgpt analyze` results. No API, flag, or configuration change.
