### PR TITLE
fix(analyzer): skip non-Service HTTPRoute backends; serialize Gateway API scheme registration

### DIFF
--- a/pkg/analyzer/gateway.go
+++ b/pkg/analyzer/gateway.go
@@ -37,7 +37,7 @@ func (GatewayAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	gtwList := &gtwapi.GatewayList{}
 	gc := &gtwapi.GatewayClass{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
+	err := ensureGatewayScheme(client.Scheme())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/gateway_scheme.go
+++ b/pkg/analyzer/gateway_scheme.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	gtwapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// The Gateway API analyzers (GatewayClass, Gateway, HTTPRoute) run concurrently
+// (see analysis.RunAnalysis with max_concurrency). Each used to call
+// gtwapi.AddToScheme(client.Scheme()) at the start of Analyze, mutating the shared
+// runtime.Scheme maps concurrently and triggering a fatal "concurrent map writes".
+//
+// ensureGatewayScheme serializes the registration and performs it at most once per
+// scheme, so after the first call there are no further writes to race against.
+var (
+	gatewaySchemeMu   sync.Mutex
+	gatewaySchemeDone = map[*runtime.Scheme]struct{}{}
+)
+
+func ensureGatewayScheme(scheme *runtime.Scheme) error {
+	gatewaySchemeMu.Lock()
+	defer gatewaySchemeMu.Unlock()
+	if _, ok := gatewaySchemeDone[scheme]; ok {
+		return nil
+	}
+	if err := gtwapi.AddToScheme(scheme); err != nil {
+		return err
+	}
+	gatewaySchemeDone[scheme] = struct{}{}
+	return nil
+}

--- a/pkg/analyzer/gatewayclass.go
+++ b/pkg/analyzer/gatewayclass.go
@@ -35,7 +35,7 @@ func (GatewayClassAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 
 	gcList := &gtwapi.GatewayClassList{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
+	err := ensureGatewayScheme(client.Scheme())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/httproute.go
+++ b/pkg/analyzer/httproute.go
@@ -38,7 +38,7 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	gtw := &gtwapi.Gateway{}
 	service := &corev1.Service{}
 	client := a.Client.CtrlClient
-	err := gtwapi.AddToScheme(client.Scheme())
+	err := ensureGatewayScheme(client.Scheme())
 	if err != nil {
 		return nil, err
 	}
@@ -157,6 +157,15 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 		// Check if the Backends are valid services and ports are matching with services Ports
 		for _, rule := range route.Spec.Rules {
 			for _, backend := range rule.BackendRefs {
+				// Only core Kubernetes Services are validated here. Backends that
+				// reference a different Group/Kind (e.g. Envoy Gateway's
+				// gateway.envoyproxy.io/Backend, or GRPC backends) are not Services
+				// and must be skipped, otherwise they are falsely reported as
+				// missing Services.
+				if (backend.Group != nil && *backend.Group != "") ||
+					(backend.Kind != nil && *backend.Kind != "Service") {
+					continue
+				}
 				err := client.Get(a.Context, ctrl.ObjectKey{Namespace: route.Namespace, Name: string(backend.Name)}, service, &ctrl.GetOptions{})
 				if errors.IsNotFound(err) {
 					failures = append(failures, common.Failure{
@@ -177,6 +186,9 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						},
 					})
 				} else {
+					if backend.Port == nil {
+						continue
+					}
 					portMatch := false
 					for _, svcPort := range service.Spec.Ports {
 						if int32(*backend.Port) == svcPort.Port {

--- a/pkg/analyzer/httproute_test.go
+++ b/pkg/analyzer/httproute_test.go
@@ -2,6 +2,7 @@ package analyzer
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -400,5 +401,57 @@ func TestSvcDifferentPortHTTRouteAnalyzer(t *testing.T) {
 
 	if !errorFound {
 		t.Errorf("Expected message, <%s> , not found in HTTPRoute's analysis results", want)
+	}
+}
+
+func BuildHTTPRouteWithBackendRef(backendName, gtwName gtwapi.ObjectName, gtwNamespace gtwapi.Namespace, group *gtwapi.Group, kind *gtwapi.Kind, svcPort *gtwapi.PortNumber, namespace string) gtwapi.HTTPRoute {
+	route := BuildHTTPRoute(backendName, gtwName, gtwNamespace, svcPort, namespace)
+	ref := &route.Spec.Rules[0].BackendRefs[0].BackendObjectReference
+	ref.Group = group
+	ref.Kind = kind
+	return route
+}
+
+// A backendRef that references a non-Service Group/Kind (e.g. Envoy Gateway's
+// gateway.envoyproxy.io/Backend) must not be validated as a core Service,
+// otherwise it is falsely reported as a missing Service.
+func TestGWNonServiceBackendHTTPRouteAnalyzer(t *testing.T) {
+	backendName := gtwapi.ObjectName("charles-closeli-cn")
+	gtwName := gtwapi.ObjectName("gatewayname")
+	gtwNamespace := gtwapi.Namespace("default")
+	httpRouteNamespace := "default"
+	group := gtwapi.Group("gateway.envoyproxy.io")
+	kind := gtwapi.Kind("Backend")
+
+	HTTPRoute := BuildHTTPRouteWithBackendRef(backendName, gtwName, gtwNamespace, &group, &kind, nil, httpRouteNamespace)
+	Gateway := BuildRouteGateway("default", "gatewayname", "All")
+
+	scheme := scheme.Scheme
+	if err := gtwapi.Install(scheme); err != nil {
+		t.Error(err)
+	}
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{&HTTPRoute, &Gateway}
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := HTTPRouteAnalyzer{}
+	config := common.Analyzer{
+		Client:    &kubernetes.Client{CtrlClient: fakeClient},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, analysis := range analysisResults {
+		for _, got := range analysis.Error {
+			if strings.Contains(got.Text, "uses the Service") {
+				t.Errorf("non-Service backend falsely reported as missing Service: %s", got.Text)
+			}
+		}
 	}
 }


### PR DESCRIPTION
## What this fixes

Two Gateway API analyzer bugs, both hit on clusters that use Envoy Gateway (or any non-Service HTTPRoute backend). Found on `v0.4.36`; the analyzer files are identical on `main`. The two fixes are independent and can be split into separate PRs if preferred.

### 1. HTTPRoute reports non-Service backends as missing Services

`HTTPRouteAnalyzer` looks up every `backendRef` as a core `Service` **without checking `Group`/`Kind`**, so a backend that references a non-Service resource (e.g. Envoy Gateway's `gateway.envoyproxy.io/Backend`, or a GRPC backend) is falsely reported:

```
HTTPRoute uses the Service 'ns/name' which does not exist.
```

Example backend that triggers it:

```yaml
backendRefs:
- group: gateway.envoyproxy.io
  kind: Backend
  name: my-backend
```

**Fix:** skip backendRefs whose `Group` is non-empty or whose `Kind != "Service"`, and nil-guard `*backend.Port`.

### 2. Concurrent Gateway API scheme registration crashes the process

`GatewayClass`, `Gateway` and `HTTPRoute` analyzers each call `gtwapi.AddToScheme(client.Scheme())` at the start of `Analyze`. Analyzers run concurrently (`max_concurrency`), so multiple goroutines write the shared `runtime.Scheme` maps at once:

```
fatal error: concurrent map writes
...
k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName(...)
sigs.k8s.io/gateway-api/apis/v1.addKnownTypes(...)
github.com/k8sgpt-ai/k8sgpt/pkg/analyzer.HTTPRouteAnalyzer.Analyze  pkg/analyzer/httproute.go:41
github.com/k8sgpt-ai/k8sgpt/pkg/analysis.(*Analysis).executeAnalyzer  pkg/analysis/analysis.go:428
```

Because this is a `fatal error` (not recoverable), the whole process exits (code 2) and restart-loops. It is most frequent on the instance that runs all three analyzers.

**Fix:** add `ensureGatewayScheme()`, which registers gateway-api types **at most once per scheme, under a mutex** — removing both the concurrent writes and the repeated writes. (An alternative would be to register the types when the ctrl client is built in `pkg/kubernetes`; this keeps the change local to the analyzers.)

## Testing

- Added `TestGWNonServiceBackendHTTPRouteAnalyzer` (an HTTPRoute whose backend is an Envoy Gateway `Backend`). It **fails without fix #1** — reproducing the false positive — and passes with it.
- `go build`, `go vet`, and `go test ./pkg/analyzer/` pass; existing Gateway/GatewayClass/HTTPRoute tests are unchanged.
