### PR TITLE
feat: add LiteLLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,9 +487,24 @@ Unused:
 > watsonxai
 > customrest
 > ibmwatsonxai
+> litellm
 ```
 
 For detailed documentation on how to configure and use each provider see [here](https://docs.k8sgpt.ai/reference/providers/backend/).
+
+_Using LiteLLM (route to 100+ providers through one proxy)_
+
+The `litellm` backend talks to a [LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy),
+which exposes an OpenAI-compatible API in front of 100+ providers (OpenAI, Azure,
+Anthropic, Bedrock, Gemini, ...). It defaults to the proxy's standard local
+endpoint (`http://localhost:4000/v1`); use `--model` to pick a model configured
+in your proxy, and `--baseurl` to point at a remote proxy. A password is only
+needed if your proxy enforces a virtual key.
+
+```
+k8sgpt auth add --backend litellm --model gpt-4o
+k8sgpt analyze --explain --backend litellm
+```
 
 _To set a new default provider_
 

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -38,6 +38,7 @@ var (
 		&IBMWatsonxAIClient{},
 		&GroqClient{},
 		&AmazonBedrockMantleClient{},
+		&LiteLLMClient{},
 	}
 	Backends = []string{
 		openAIClientName,
@@ -58,6 +59,7 @@ var (
 		ibmWatsonxAIClientName,
 		groqAIClientName,
 		bedrockMantleClientName,
+		liteLLMClientName,
 	}
 )
 
@@ -209,7 +211,7 @@ func (p *AIProvider) GetCustomHeaders() []http.Header {
 	return p.CustomHeaders
 }
 
-var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "amazonbedrockconverse", "googlevertexai", "oci", "customrest", "bedrockmantle"}
+var passwordlessProviders = []string{"localai", "ollama", "amazonsagemaker", "amazonbedrock", "amazonbedrockconverse", "googlevertexai", "oci", "customrest", "bedrockmantle", "litellm"}
 
 func NeedPassword(backend string) bool {
 	for _, b := range passwordlessProviders {

--- a/pkg/ai/litellm.go
+++ b/pkg/ai/litellm.go
@@ -97,6 +97,9 @@ func (c *LiteLLMClient) GetCompletion(ctx context.Context, prompt string) (strin
 	if err != nil {
 		return "", err
 	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned from LiteLLM")
+	}
 	return resp.Choices[0].Message.Content, nil
 }
 

--- a/pkg/ai/litellm.go
+++ b/pkg/ai/litellm.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+const liteLLMClientName = "litellm"
+
+// Default LiteLLM proxy endpoint (OpenAI-compatible). The LiteLLM proxy exposes
+// an OpenAI-compatible API, so it is reached through the same go-openai client
+// as the OpenAI backend, only with a different base URL. Point `baseurl` at your
+// proxy to route k8sgpt through any of the 100+ providers LiteLLM supports.
+const liteLLMBaseURL = "http://localhost:4000/v1"
+
+type LiteLLMClient struct {
+	nopCloser
+
+	client      *openai.Client
+	model       string
+	temperature float32
+	topP        float32
+}
+
+func (c *LiteLLMClient) Configure(config IAIConfig) error {
+	token := config.GetPassword()
+	defaultConfig := openai.DefaultConfig(token)
+	proxyEndpoint := config.GetProxyEndpoint()
+
+	baseURL := config.GetBaseURL()
+	if baseURL != "" {
+		defaultConfig.BaseURL = baseURL
+	} else {
+		defaultConfig.BaseURL = liteLLMBaseURL
+	}
+
+	transport := &http.Transport{}
+	if proxyEndpoint != "" {
+		proxyUrl, err := url.Parse(proxyEndpoint)
+		if err != nil {
+			return err
+		}
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+
+	customHeaders := config.GetCustomHeaders()
+	defaultConfig.HTTPClient = &http.Client{
+		Transport: &OpenAIHeaderTransport{
+			Origin:  transport,
+			Headers: customHeaders,
+		},
+	}
+
+	client := openai.NewClientWithConfig(defaultConfig)
+	if client == nil {
+		return errors.New("error creating LiteLLM client")
+	}
+	c.client = client
+	c.model = config.GetModel()
+	c.temperature = config.GetTemperature()
+	c.topP = config.GetTopP()
+	return nil
+}
+
+func (c *LiteLLMClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	resp, err := c.client.CreateChatCompletion(ctx, openai.ChatCompletionRequest{
+		Model: c.model,
+		Messages: []openai.ChatCompletionMessage{
+			{
+				Role:    "user",
+				Content: prompt,
+			},
+		},
+		Temperature:      c.temperature,
+		MaxTokens:        maxToken,
+		PresencePenalty:  presencePenalty,
+		FrequencyPenalty: frequencyPenalty,
+		TopP:             c.topP,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Choices[0].Message.Content, nil
+}
+
+func (c *LiteLLMClient) GetName() string {
+	return liteLLMClientName
+}

--- a/pkg/ai/litellm_test.go
+++ b/pkg/ai/litellm_test.go
@@ -101,3 +101,18 @@ func TestLiteLLMClient_GetCompletion(t *testing.T) {
 	assert.Equal(t, "Bearer sk-litellm-virtual-key", gotAuth)
 	assert.Equal(t, "/v1/chat/completions", gotPath)
 }
+
+func TestLiteLLMClient_GetCompletionNoChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	c := &LiteLLMClient{}
+	require.NoError(t, c.Configure(&litellmMockConfig{baseURL: server.URL + "/v1", model: "gpt-4o"}))
+
+	_, err := c.GetCompletion(context.Background(), "why is my pod crashing?")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no completion choices")
+}

--- a/pkg/ai/litellm_test.go
+++ b/pkg/ai/litellm_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// litellmMockConfig implements IAIConfig for LiteLLM backend tests.
+type litellmMockConfig struct {
+	baseURL       string
+	password      string
+	model         string
+	customHeaders []http.Header
+}
+
+func (m *litellmMockConfig) GetPassword() string             { return m.password }
+func (m *litellmMockConfig) GetModel() string                { return m.model }
+func (m *litellmMockConfig) GetBaseURL() string              { return m.baseURL }
+func (m *litellmMockConfig) GetProxyEndpoint() string        { return "" }
+func (m *litellmMockConfig) GetEndpointName() string         { return "" }
+func (m *litellmMockConfig) GetEngine() string               { return "" }
+func (m *litellmMockConfig) GetTemperature() float32         { return 0.0 }
+func (m *litellmMockConfig) GetProviderRegion() string       { return "" }
+func (m *litellmMockConfig) GetTopP() float32                { return 0.0 }
+func (m *litellmMockConfig) GetTopK() int32                  { return 0 }
+func (m *litellmMockConfig) GetMaxTokens() int               { return 0 }
+func (m *litellmMockConfig) GetStopSequences() []string      { return nil }
+func (m *litellmMockConfig) GetProviderId() string           { return "" }
+func (m *litellmMockConfig) GetCompartmentId() string        { return "" }
+func (m *litellmMockConfig) GetOrganizationId() string       { return "" }
+func (m *litellmMockConfig) GetAzureAPIType() string         { return "" }
+func (m *litellmMockConfig) GetAzureAPIVersion() string      { return "" }
+func (m *litellmMockConfig) GetCustomHeaders() []http.Header { return m.customHeaders }
+
+func TestLiteLLMClient_GetName(t *testing.T) {
+	c := &LiteLLMClient{}
+	assert.Equal(t, "litellm", c.GetName())
+}
+
+func TestLiteLLMClient_ConfigureDefaultsToProxyBaseURL(t *testing.T) {
+	c := &LiteLLMClient{}
+	err := c.Configure(&litellmMockConfig{model: "gpt-4o"})
+	require.NoError(t, err)
+	require.NotNil(t, c.client)
+	assert.Equal(t, "gpt-4o", c.model)
+}
+
+func TestLiteLLMClient_IsRegisteredAndPasswordless(t *testing.T) {
+	// Resolvable by name through the backend registry.
+	assert.IsType(t, &LiteLLMClient{}, NewClient(liteLLMClientName))
+	assert.Contains(t, Backends, liteLLMClientName)
+	// Self-hosted proxies are commonly keyless, so no password is required.
+	assert.False(t, NeedPassword(liteLLMClientName))
+}
+
+func TestLiteLLMClient_GetCompletion(t *testing.T) {
+	var gotAuth string
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"role": "assistant", "content": "the cluster is healthy"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := &LiteLLMClient{}
+	err := c.Configure(&litellmMockConfig{
+		baseURL:  server.URL + "/v1",
+		password: "sk-litellm-virtual-key",
+		model:    "gpt-4o",
+	})
+	require.NoError(t, err)
+
+	resp, err := c.GetCompletion(context.Background(), "why is my pod crashing?")
+	require.NoError(t, err)
+	assert.Equal(t, "the cluster is healthy", resp)
+	assert.Equal(t, "Bearer sk-litellm-virtual-key", gotAuth)
+	assert.Equal(t, "/v1/chat/completions", gotPath)
+}


### PR DESCRIPTION


## 📑 Description

Adds `litellm` as a first-class backend so k8sgpt can route `--explain` through a
[LiteLLM proxy](https://docs.litellm.ai/docs/simple_proxy) and reach 100+ providers
(OpenAI, Azure, Anthropic, Bedrock, Gemini, ...) behind one OpenAI-compatible
endpoint. It reuses the existing `go-openai` client, mirroring `groq.go`/`localai.go`,
so it inherits custom-header + proxy support with no new dependencies.

Additive only — no existing backend is touched, default behavior is unchanged.

**Changes**
- `pkg/ai/litellm.go` — new `LiteLLMClient` implementing `IAI` via `go-openai`;
  defaults to the proxy's standard endpoint (`http://localhost:4000/v1`), honors
  `--baseurl` / `--proxyEndpoint` / custom headers.
- `pkg/ai/iai.go` — registered in `clients` + `Backends`, and password-optional
  (`passwordlessProviders`) since self-hosted proxies are commonly keyless.
- `pkg/ai/litellm_test.go` — unit tests (name, default base URL, registry +
  passwordless, `GetCompletion` round-trip, empty-choices guard).
- `README.md` — backend list entry + usage example.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

**`gofmt` / `go vet`:** clean. Commits are DCO signed-off and use conventional-commit messages.

**Unit tests — `go test ./pkg/ai/...`:**

```
=== RUN   TestLiteLLMClient_GetName
--- PASS: TestLiteLLMClient_GetName (0.00s)
=== RUN   TestLiteLLMClient_ConfigureDefaultsToProxyBaseURL
--- PASS: TestLiteLLMClient_ConfigureDefaultsToProxyBaseURL (0.00s)
=== RUN   TestLiteLLMClient_IsRegisteredAndPasswordless
--- PASS: TestLiteLLMClient_IsRegisteredAndPasswordless (0.00s)
=== RUN   TestLiteLLMClient_GetCompletion
--- PASS: TestLiteLLMClient_GetCompletion (0.00s)
=== RUN   TestLiteLLMClient_GetCompletionNoChoices
--- PASS: TestLiteLLMClient_GetCompletionNoChoices (0.00s)
ok  	github.com/k8sgpt-ai/k8sgpt/pkg/ai   # full package suite green
```

**Live E2E** — drove the real `LiteLLMClient` against a running LiteLLM proxy
fronting a live model, exercising the full chain (`LiteLLMClient.GetCompletion` →
`go-openai` → LiteLLM proxy → upstream provider → parsed response):

```
[LIVE] backend=litellm baseURL=http://localhost:4000/v1
[LIVE] response="healthy"
--- PASS: TestLiteLLMLive (2.99s)
```

(The live test is a local scratch harness, not part of the committed diff.)

**Example usage** — a LiteLLM proxy (Python) fronting OpenAI + Anthropic:

```yaml
# config.yaml
model_list:
  - model_name: gpt-4o
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude
    litellm_params:
      model: anthropic/claude-3-5-sonnet-latest
      api_key: os.environ/ANTHROPIC_API_KEY
litellm_settings:
  drop_params: true
```

```bash
pip install "litellm[proxy]"
litellm --config config.yaml            # OpenAI-compatible API on :4000

k8sgpt auth add --backend litellm --model gpt-4o     # keyless proxy
k8sgpt analyze --explain --backend litellm
```
