### PR TITLE
fix: skip empty results from custom analyzers with no findings

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -301,6 +301,27 @@ func (a *Analysis) RunCustomAnalysis() {
 			}
 
 			result, err := canClient.Run()
+			if err == nil && result.Name == "" && len(result.Error) == 0 {
+				// The analyzer returned RunResponse.Result == nil, i.e. "I ran and found nothing".
+				// custom.Client.Run() only populates its result when Result != nil, so what we hold
+				// here is the zero value: no Name, no Error.
+				//
+				// Appending it produces a result no consumer can use, and it is actively harmful to
+				// k8sgpt-operator: MapResults derives Result.metadata.name from result.Name, so an
+				// empty Name yields an object that fails CRD validation ("metadata.name: Required
+				// value, spec.error: Required value"). processRawResults returns on the first such
+				// failure, so ONE analyzer with no findings aborts the reconcile before the
+				// remaining results are written — and because it ranges over a map, the subset that
+				// survives differs every cycle.
+				//
+				// Skipping it is also what the CLI already implies: a custom analyzer with nothing
+				// to report should contribute nothing, not an empty entry.
+				if verbose {
+					fmt.Printf("Debug: %s completed with no findings.\n", cAnalyzer.Name)
+				}
+				<-semaphore
+				return
+			}
 			if result.Kind == "" {
 				// for custom analyzer name, we must use a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.',
 				//and must start and end with an alphanumeric character (e.g. 'example.com',

--- a/pkg/analysis/analysis_test.go
+++ b/pkg/analysis/analysis_test.go
@@ -17,10 +17,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	rpc "buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc"
+	schemav1 "buf.build/gen/go/k8sgpt-ai/k8sgpt/protocolbuffers/go/schema/v1"
+	"google.golang.org/grpc"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
@@ -705,4 +710,76 @@ func TestVerbose_GetAIResults(t *testing.T) {
 	if !util.Contains(output, expected) {
 		t.Errorf("Expected output to contain: '%s', but got output: '%s'", expected, output)
 	}
+}
+
+// fakeCustomAnalyzer serves the custom-analyzer gRPC API and returns whatever it is given.
+type fakeCustomAnalyzer struct {
+	rpc.UnimplementedCustomAnalyzerServiceServer
+	resp *schemav1.RunResponse
+}
+
+func (f *fakeCustomAnalyzer) Run(context.Context, *schemav1.RunRequest) (*schemav1.RunResponse, error) {
+	return f.resp, nil
+}
+
+// serveFakeAnalyzer starts one on a free port and returns its host and port.
+func serveFakeAnalyzer(t *testing.T, resp *schemav1.RunResponse) (string, string) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	rpc.RegisterCustomAnalyzerServiceServer(srv, &fakeCustomAnalyzer{resp: resp})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	host, port, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("split host/port: %v", err)
+	}
+	return host, port
+}
+
+// A custom analyzer that returns RunResponse.Result == nil means "I ran and found nothing". It must
+// contribute NO result — appending the zero value yields a result with an empty Name that no
+// consumer can use, and k8sgpt-operator turns it into a Result CR whose metadata.name is "", failing
+// CRD validation and aborting the reconcile before the remaining analyzers' results are written.
+func TestRunCustomAnalysisNilResultProducesNoResult(t *testing.T) {
+	host, port := serveFakeAnalyzer(t, &schemav1.RunResponse{})
+	viper.Set("verbose", false)
+	viper.Set("custom_analyzers", []map[string]interface{}{
+		{"name": "EmptyAnalyzer", "connection": map[string]interface{}{"url": host, "port": port}},
+	})
+	t.Cleanup(func() { viper.Set("custom_analyzers", []interface{}{}) })
+
+	a := &Analysis{MaxConcurrency: 1}
+	a.RunCustomAnalysis()
+
+	require.Empty(t, a.Errors, "an analyzer with no findings is not an error")
+	require.Empty(t, a.Results, "a nil Result must not be recorded as a result")
+}
+
+// The normal path must be untouched: a populated Result is still recorded, and Kind still defaults
+// to the analyzer's configured name when the analyzer leaves it blank.
+func TestRunCustomAnalysisPopulatedResultIsRecorded(t *testing.T) {
+	host, port := serveFakeAnalyzer(t, &schemav1.RunResponse{
+		Result: &schemav1.Result{
+			Name:  "EmptyAnalyzer",
+			Error: []*schemav1.ErrorDetail{{Text: "something is wrong"}},
+		},
+	})
+	viper.Set("verbose", false)
+	viper.Set("custom_analyzers", []map[string]interface{}{
+		{"name": "EmptyAnalyzer", "connection": map[string]interface{}{"url": host, "port": port}},
+	})
+	t.Cleanup(func() { viper.Set("custom_analyzers", []interface{}{}) })
+
+	a := &Analysis{MaxConcurrency: 1}
+	a.RunCustomAnalysis()
+
+	require.Empty(t, a.Errors)
+	require.Len(t, a.Results, 1)
+	require.Equal(t, "EmptyAnalyzer", a.Results[0].Name)
+	require.Equal(t, "EmptyAnalyzer", a.Results[0].Kind, "Kind should default to the analyzer name")
+	require.Len(t, a.Results[0].Error, 1)
 }


### PR DESCRIPTION
A custom analyzer with nothing to report returns `RunResponse.Result == nil`. `custom.Client.Run()` only populates its result when `Result != nil`, so it hands back the zero value — no `Name`, no `Error` — with a nil error, and `RunCustomAnalysis` appends that to `a.Results`.

### Why it matters

The appended entry is unusable to consumers, and it breaks **k8sgpt-operator**. `MapResults` derives `Result.metadata.name` from `result.Name`, so an empty name produces an object that fails CRD validation:

```
Result.core.k8sgpt.ai "" is invalid: [metadata.name: Required value, spec.error: Required value]
```

`processRawResults` does `return err` on the first failed create, so **one custom analyzer with no findings aborts the reconcile before the remaining results are written**. It ranges over a map, so the subset that survives differs every cycle, and other analyzers' Result CRs silently go stale — with nothing in the analyzer logs pointing at the cause. On our clusters this left Result CRs lagging from a few resourceVersions to tens of millions behind while every analyzer reported healthy counts.

### Why the analyzer cannot work around it

Both encodings of "no findings" are rejected:

- nil `Result` → empty `metadata.name`
- named `Result` with an empty `Error` list → still `spec.error: Required value`

So "I ran and found nothing" is currently unrepresentable without breaking the operator.

### The change

Skip the result when the analyzer returned nothing. This matches what the CLI already implies: an analyzer with no findings should contribute no entry. Analyzers that *do* report findings are unaffected, and a transport/analyzer error is still recorded in `a.Errors` as before.

### Tests

`pkg/analysis/analysis_test.go` now starts a real custom-analyzer gRPC server and asserts both directions:

- `TestRunCustomAnalysisNilResultProducesNoResult` — a nil `Result` yields no result **and** no error (no findings is not an error). Fails without this change with `Should be empty, but was [{EmptyAnalyzer  []  }]`.
- `TestRunCustomAnalysisPopulatedResultIsRecorded` — a populated `Result` is still recorded, with `Kind` still defaulting to the configured analyzer name.

`go test ./pkg/analysis/ ./pkg/custom/` passes.

### Note

A defensive guard in k8sgpt-operator (skipping a `resultSpec` with an empty `Name` in `MapResults`, or not aborting the whole loop on one bad result) would also be worth having, since it is the component that actually fails. Happy to open that separately if useful — fixing it here stops the empty entry being produced in the first place.