### PR TITLE
fix: skip failure report for jobs that completed successfully after retries

### DIFF
--- a/pkg/analyzer/job.go
+++ b/pkg/analyzer/job.go
@@ -19,6 +19,8 @@ import (
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -68,7 +70,11 @@ func (analyzer JobAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 				},
 			})
 		}
-		if Job.Status.Failed > 0 {
+		// A Job that has reached a successful terminal state (Complete or
+		// SuccessCriteriaMet) should not be reported as failed even when
+		// Status.Failed is non-zero: failed attempts that were retried within
+		// backoffLimit are normal and the Job is healthy.
+		if Job.Status.Failed > 0 && !jobHasSucceeded(Job) {
 			doc := apiDoc.GetApiDocV2("status.failed")
 
 			failure := common.Failure{
@@ -114,4 +120,17 @@ func (analyzer JobAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 	}
 
 	return a.Results, nil
+}
+
+// jobHasSucceeded reports whether the Job has reached a successful terminal
+// state. Kubernetes records a Complete condition when all pods succeed, and a
+// SuccessCriteriaMet condition when the Job's success policy is met.
+func jobHasSucceeded(job batchv1.Job) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Status == corev1.ConditionTrue &&
+			(condition.Type == batchv1.JobComplete || condition.Type == batchv1.JobSuccessCriteriaMet) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/analyzer/job_test.go
+++ b/pkg/analyzer/job_test.go
@@ -264,3 +264,74 @@ func TestJobAnalyzerLabelSelector(t *testing.T) {
 	require.Equal(t, 1, len(results))
 	require.Equal(t, "default/job-with-label", results[0].Name)
 }
+
+func TestJobAnalyzerSucceededAfterRetries(t *testing.T) {
+	// A Job that failed some pods but eventually completed successfully.
+	// Status.Failed remains > 0 even though the Job succeeded (condition Complete=True).
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "retried-job",
+			Namespace: "default",
+		},
+		Spec: batchv1.JobSpec{},
+		Status: batchv1.JobStatus{
+			Failed:    2,
+			Succeeded: 1,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobComplete,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(job),
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := JobAnalyzer{}
+	results, err := analyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Len(t, results, 0, "a Job that completed successfully after retries should not be reported as failed")
+}
+
+func TestJobAnalyzerFailedConditionOverridesRetries(t *testing.T) {
+	// A Job that exhausted its backoff limit: Failed condition is True even
+	// though some pods may have succeeded. Must still be reported.
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "failed-job",
+			Namespace: "default",
+		},
+		Spec: batchv1.JobSpec{},
+		Status: batchv1.JobStatus{
+			Failed:    3,
+			Succeeded: 1,
+			Conditions: []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(job),
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	analyzer := JobAnalyzer{}
+	results, err := analyzer.Analyze(config)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "a Job with Failed condition should still be reported")
+	require.Equal(t, "default/failed-job", results[0].Name)
+}


### PR DESCRIPTION
Closes #1723

## 📑 Description

The Job analyzer reported a Job as failed whenever `Status.Failed > 0`, without consulting the Job's terminal state in `status.conditions`. Kubernetes Jobs retry failed pods within `spec.backoffLimit` (default 6), so a Job that failed a few pods and then completed successfully still has `status.failed > 0` — and was wrongly reported as `"Job <name> has failed"`.

This PR guards the failure report with a new `jobHasSucceeded` helper that inspects `status.conditions` and returns true when either `Complete` or `SuccessCriteriaMet` (Kubernetes 1.31+) is `True`. A genuinely failed Job (`Failed=True`) is still reported.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1` — passes (including the two new regression tests)
- `go vet ./pkg/analyzer/` — clean
- `git diff --check` — clean

Regression tests added:
- `TestJobAnalyzerSucceededAfterRetries` — `Complete=True` with `status.failed: 2` is not reported
- `TestJobAnalyzerFailedConditionOverridesRetries` — `Failed=True` is still reported