### PR TITLE
fix: mask sensitive values in HTTPRoute analyzer failures

### DIFF
--- a/pkg/analyzer/httproute.go
+++ b/pkg/analyzer/httproute.go
@@ -71,12 +71,12 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 					),
 					Sensitive: []common.Sensitive{
 						{
-							Unmasked: gtw.Namespace,
-							Masked:   util.MaskString(gtw.Namespace),
+							Unmasked: namespace,
+							Masked:   util.MaskString(namespace),
 						},
 						{
-							Unmasked: gtw.Name,
-							Masked:   util.MaskString(gtw.Name),
+							Unmasked: string(gtwref.Name),
+							Masked:   util.MaskString(string(gtwref.Name)),
 						},
 					},
 				})
@@ -167,12 +167,12 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 						),
 						Sensitive: []common.Sensitive{
 							{
-								Unmasked: service.Namespace,
-								Masked:   util.MaskString(service.Namespace),
+								Unmasked: route.Namespace,
+								Masked:   util.MaskString(route.Namespace),
 							},
 							{
-								Unmasked: service.Name,
-								Masked:   util.MaskString(service.Name),
+								Unmasked: string(backend.Name),
+								Masked:   util.MaskString(string(backend.Name)),
 							},
 						},
 					})
@@ -203,7 +203,7 @@ func (HTTPRouteAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 								},
 								{
 									Unmasked: service.Namespace,
-									Masked:   service.Namespace,
+									Masked:   util.MaskString(service.Namespace),
 								},
 							},
 						})

--- a/pkg/analyzer/httproute_test.go
+++ b/pkg/analyzer/httproute_test.go
@@ -2,10 +2,12 @@ package analyzer
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -400,5 +402,141 @@ func TestSvcDifferentPortHTTRouteAnalyzer(t *testing.T) {
 
 	if !errorFound {
 		t.Errorf("Expected message, <%s> , not found in HTTPRoute's analysis results", want)
+	}
+}
+
+func runHTTPRouteAnalyzer(t *testing.T, objects ...runtime.Object) []common.Result {
+	t.Helper()
+	scheme := scheme.Scheme
+	if err := gtwapi.Install(scheme); err != nil {
+		t.Error(err)
+	}
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Error(err)
+	}
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+	analyzerInstance := HTTPRouteAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	results, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	return results
+}
+
+func gatewayPtr(gateway gtwapi.Gateway) *gtwapi.Gateway {
+	return &gateway
+}
+
+func TestHTTPRouteAnalyzerSensitiveMasking(t *testing.T) {
+	svcPort := gtwapi.PortNumber(1027)
+	backendName := gtwapi.ObjectName("portsvc")
+	tests := []struct {
+		name     string
+		route    gtwapi.HTTPRoute
+		gateway  *gtwapi.Gateway
+		service  *corev1.Service
+		wantText string
+		leaked   []string
+	}{
+		{
+			name: "gateway missing",
+			route: BuildHTTPRoute(
+				gtwapi.ObjectName("svcname"),
+				gtwapi.ObjectName("gtwmissing"),
+				gtwapi.Namespace("missingns"),
+				&svcPort,
+				"default",
+			),
+			wantText: "HTTPRoute uses the Gateway 'missingns/gtwmissing' which does not exist in the same namespace.",
+			leaked:   []string{"missingns", "gtwmissing"},
+		},
+		{
+			name: "service missing",
+			route: BuildHTTPRoute(
+				gtwapi.ObjectName("svcmissing"),
+				gtwapi.ObjectName("gtwpresent"),
+				gtwapi.Namespace("default"),
+				&svcPort,
+				"default",
+			),
+			gateway:  gatewayPtr(BuildRouteGateway("default", "gtwpresent", "Same")),
+			wantText: "HTTPRoute uses the Service 'default/svcmissing' which does not exist.",
+			leaked:   []string{"svcmissing", "default"},
+		},
+		{
+			name: "service port mismatch",
+			route: BuildHTTPRoute(
+				backendName,
+				gtwapi.ObjectName("gtwpresent"),
+				gtwapi.Namespace("default"),
+				&svcPort,
+				"default",
+			),
+			gateway: gatewayPtr(BuildRouteGateway("default", "gtwpresent", "Same")),
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "portsvc",
+					Namespace: "default",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Protocol:   "TCP",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+			wantText: "HTTPRoute's backend service 'portsvc' is using port '1027' but the corresponding K8s service 'default/portsvc' isn't configured with the same port.",
+			leaked:   []string{"portsvc", "default"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objects := []runtime.Object{&tt.route}
+			if tt.gateway != nil {
+				objects = append(objects, tt.gateway)
+			}
+			if tt.service != nil {
+				objects = append(objects, tt.service)
+			}
+			results := runHTTPRouteAnalyzer(t, objects...)
+
+			var failure *common.Failure
+			for i := range results {
+				for j := range results[i].Error {
+					if results[i].Error[j].Text == tt.wantText {
+						failure = &results[i].Error[j]
+					}
+				}
+			}
+			if failure == nil {
+				t.Fatalf("Expected message <%s> not found in HTTPRoute's analysis results", tt.wantText)
+			}
+
+			for _, s := range failure.Sensitive {
+				if !strings.Contains(failure.Text, s.Unmasked) {
+					t.Errorf("Sensitive.Unmasked %q not found in failure text %q; masking is ineffective", s.Unmasked, failure.Text)
+				}
+			}
+			masked := failure.Text
+			for _, s := range failure.Sensitive {
+				masked = util.ReplaceIfMatch(masked, s.Unmasked, s.Masked)
+			}
+			for _, value := range tt.leaked {
+				if strings.Contains(masked, value) {
+					t.Errorf("value %q leaked after masking: %q still contains %q", value, masked, value)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 📑 Description

When `--anonymize` is enabled, three HTTPRoute analyzer failure paths still exposed the real resource namespace/name to the model because the `Sensitive` entries did not match the values embedded in the failure text:

- Gateway not found: `Sensitive` used the empty `gtw` object instead of the route's namespace and the gateway reference name.
- Service not found: `Sensitive` used the empty `service` object instead of the route's namespace and the backend reference name.
- Service port mismatch: the namespace was included without `util.MaskString`, so it was never replaced.

This PR fixes the `Sensitive` entries and adds a regression test covering all three paths to verify masked output no longer contains the real values.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Local verification: `go test ./pkg/analyzer/`, `go vet ./pkg/analyzer/`, and `git diff --check` all pass.