### PR TITLE
fix: harden completion calls against empty responses and hangs

### DIFF
--- a/pkg/ai/anthropic.go
+++ b/pkg/ai/anthropic.go
@@ -50,16 +50,16 @@ func (c *AnthropicClient) Configure(config IAIConfig) error {
 		opts = append(opts, option.WithAPIKey(token))
 	}
 
+	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
 	proxyEndpoint := config.GetProxyEndpoint()
 	if proxyEndpoint != "" {
 		proxyURL, err := url.Parse(proxyEndpoint)
 		if err != nil {
 			return err
 		}
-		opts = append(opts, option.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
-		}))
+		httpClient.Transport = &http.Transport{Proxy: http.ProxyURL(proxyURL)}
 	}
+	opts = append(opts, option.WithHTTPClient(httpClient))
 
 	model := config.GetModel()
 	if model == "" {

--- a/pkg/ai/azureopenai.go
+++ b/pkg/ai/azureopenai.go
@@ -58,6 +58,7 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 			Proxy: http.ProxyFromEnvironment,
 		}
 		defaultConfig.HTTPClient = &http.Client{
+			Timeout: defaultHTTPTimeout,
 			Transport: &customHeaderRoundTripper{
 				headers: customHeaders,
 				rt:      transport,
@@ -73,6 +74,7 @@ func (c *AzureAIClient) Configure(config IAIConfig) error {
 		}
 
 		defaultConfig.HTTPClient = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}
@@ -116,6 +118,9 @@ func (c *AzureAIClient) GetCompletion(ctx context.Context, prompt string) (strin
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }

--- a/pkg/ai/customrest.go
+++ b/pkg/ai/customrest.go
@@ -60,7 +60,7 @@ func (c *CustomRestClient) Configure(config IAIConfig) error {
 	c.base = baseClientURL
 
 	proxyEndpoint := config.GetProxyEndpoint()
-	c.client = http.DefaultClient
+	c.client = &http.Client{Timeout: defaultHTTPTimeout}
 	if proxyEndpoint != "" {
 		proxyUrl, err := url.Parse(proxyEndpoint)
 		if err != nil {
@@ -71,6 +71,7 @@ func (c *CustomRestClient) Configure(config IAIConfig) error {
 		}
 
 		c.client = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}

--- a/pkg/ai/groq.go
+++ b/pkg/ai/groq.go
@@ -59,6 +59,7 @@ func (c *GroqClient) Configure(config IAIConfig) error {
 
 	customHeaders := config.GetCustomHeaders()
 	defaultConfig.HTTPClient = &http.Client{
+		Timeout: defaultHTTPTimeout,
 		Transport: &OpenAIHeaderTransport{
 			Origin:  transport,
 			Headers: customHeaders,
@@ -93,6 +94,9 @@ func (c *GroqClient) GetCompletion(ctx context.Context, prompt string) (string, 
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }

--- a/pkg/ai/iai.go
+++ b/pkg/ai/iai.go
@@ -16,7 +16,17 @@ package ai
 import (
 	"context"
 	"net/http"
+	"time"
 )
+
+// defaultHTTPTimeout bounds the worst-case duration of a single AI backend
+// HTTP call. It acts as a safety net for backends whose SDK does not
+// propagate the request context's deadline all the way to the transport,
+// and for callers that pass a context with no deadline of its own. It is
+// intentionally generous (rather than a strict SLA) since local/self-hosted
+// backends such as Ollama can legitimately take minutes to generate a
+// completion on constrained hardware.
+const defaultHTTPTimeout = 10 * time.Minute
 
 var (
 	clients = []IAI{

--- a/pkg/ai/ollama.go
+++ b/pkg/ai/ollama.go
@@ -49,7 +49,7 @@ func (c *OllamaClient) Configure(config IAIConfig) error {
 	}
 
 	proxyEndpoint := config.GetProxyEndpoint()
-	httpClient := http.DefaultClient
+	httpClient := &http.Client{Timeout: defaultHTTPTimeout}
 	if proxyEndpoint != "" {
 		proxyUrl, err := url.Parse(proxyEndpoint)
 		if err != nil {
@@ -60,6 +60,7 @@ func (c *OllamaClient) Configure(config IAIConfig) error {
 		}
 
 		httpClient = &http.Client{
+			Timeout:   defaultHTTPTimeout,
 			Transport: transport,
 		}
 	}

--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -67,6 +67,7 @@ func (c *OpenAIClient) Configure(config IAIConfig) error {
 
 	customHeaders := config.GetCustomHeaders()
 	defaultConfig.HTTPClient = &http.Client{
+		Timeout: defaultHTTPTimeout,
 		Transport: &OpenAIHeaderTransport{
 			Origin:  transport,
 			Headers: customHeaders,
@@ -102,6 +103,9 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 	})
 	if err != nil {
 		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned")
 	}
 	return resp.Choices[0].Message.Content, nil
 }


### PR DESCRIPTION
## 📑 Description

Split out from #1712 per review feedback (one narrow fix per PR).

Two related robustness gaps in the AI backend clients:

- The OpenAI, Azure OpenAI, and Groq clients indexed `resp.Choices[0]` without checking the slice was non-empty. A content-filtered or safety-blocked response with zero choices panicked mid-analysis, losing every explanation already fetched in that run.
- None of the `http.Client` instances used by the OpenAI-compatible, custom REST, Ollama, and Anthropic clients set a `Timeout`, and the analysis context passed in has no deadline of its own. A hung AI endpoint blocked `analyze --explain` indefinitely with no way to abort short of `SIGKILL`.

Added a length check before indexing `Choices`, and a shared, generous (10 minute) default HTTP timeout — long enough not to interrupt slower local backends like Ollama — as a safety net.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
`go build ./...`, `go vet ./...`, and the full test suite pass locally.
