### PR TITLE
fix: thread analyzer context instead of context.Background()

### DIFF
--- a/pkg/analyzer/daemonset.go
+++ b/pkg/analyzer/daemonset.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -56,7 +55,7 @@ func (DaemonSetAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			})
 		}
 		for _, imagePullSecret := range ds.Spec.Template.Spec.ImagePullSecrets {
-			_, err := a.Client.GetClient().CoreV1().Secrets(ds.Namespace).Get(context.Background(), imagePullSecret.Name, metav1.GetOptions{})
+			_, err := a.Client.GetClient().CoreV1().Secrets(ds.Namespace).Get(a.Context, imagePullSecret.Name, metav1.GetOptions{})
 			if err != nil {
 				failures = append(failures, common.Failure{
 					Text: fmt.Sprintf("DaemonSet %s/%s references non-existent ImagePullSecret %s", ds.Namespace, ds.Name, imagePullSecret.Name),

--- a/pkg/analyzer/deployment.go
+++ b/pkg/analyzer/deployment.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,7 +45,7 @@ func (d DeploymentAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 		"analyzer_name": kind,
 	})
 
-	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	deployments, err := a.Client.GetClient().AppsV1().Deployments(a.Namespace).List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/mutating_webhook.go
+++ b/pkg/analyzer/mutating_webhook.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -42,7 +41,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 		"analyzer_name": kind,
 	})
 
-	mutatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().MutatingWebhookConfigurations().List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	mutatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().MutatingWebhookConfigurations().List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +57,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 			}
 			svc := webhook.ClientConfig.Service
 			// Get the service
-			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, v1.GetOptions{})
+			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(a.Context, svc.Name, v1.GetOptions{})
 			if err != nil {
 				// If the service is not found, we can't check the pods
 				failures = append(failures, common.Failure{
@@ -88,7 +87,7 @@ func (MutatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, erro
 				continue
 			}
 			// Get pods within service
-			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
+			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(a.Context, v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),
 			})
 			if err != nil {

--- a/pkg/analyzer/validating_webhook.go
+++ b/pkg/analyzer/validating_webhook.go
@@ -14,7 +14,6 @@ limitations under the License.
 package analyzer
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
@@ -42,7 +41,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 		"analyzer_name": kind,
 	})
 
-	validatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(context.Background(), v1.ListOptions{LabelSelector: a.LabelSelector})
+	validatingWebhooks, err := a.Client.GetClient().AdmissionregistrationV1().ValidatingWebhookConfigurations().List(a.Context, v1.ListOptions{LabelSelector: a.LabelSelector})
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +55,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 			}
 			svc := webhook.ClientConfig.Service
 			// Get the service
-			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(context.Background(), svc.Name, v1.GetOptions{})
+			service, err := a.Client.GetClient().CoreV1().Services(svc.Namespace).Get(a.Context, svc.Name, v1.GetOptions{})
 			if err != nil {
 				// If the service is not found, we can't check the pods
 				failures = append(failures, common.Failure{
@@ -86,7 +85,7 @@ func (ValidatingWebhookAnalyzer) Analyze(a common.Analyzer) ([]common.Result, er
 				continue
 			}
 			// Get pods within service
-			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(context.Background(), v1.ListOptions{
+			pods, err := a.Client.GetClient().CoreV1().Pods(svc.Namespace).List(a.Context, v1.ListOptions{
 				LabelSelector: util.MapToString(service.Spec.Selector),
 			})
 			if err != nil {


### PR DESCRIPTION
## 📑 Description

Split out from #1712 per review feedback (one narrow fix per PR).

The Deployment, DaemonSet, and Mutating/ValidatingWebhook analyzers called the Kubernetes API with a hardcoded `context.Background()` instead of the caller-supplied `a.Context`, unlike every other analyzer in the package. This silently ignored any cancellation or timeout applied to the analysis context.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
`go build ./...`, `go vet ./...`, and the full test suite pass locally.
