### PR TITLE
fix: prevent path traversal via cache key

### DIFF
--- a/pkg/cache/file_based.go
+++ b/pkg/cache/file_based.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/adrg/xdg"
 	"github.com/k8sgpt-ai/k8sgpt/pkg/util"
@@ -13,6 +14,27 @@ var _ (ICache) = (*FileBasedCache)(nil)
 
 type FileBasedCache struct {
 	noCache bool
+}
+
+// cachePath resolves key to a path inside the k8sgpt cache directory,
+// rejecting keys (e.g. containing "..") that would otherwise let a caller
+// escape that directory via path traversal.
+func cachePath(key string) (string, error) {
+	baseDir, err := xdg.CacheFile("k8sgpt")
+	if err != nil {
+		return "", err
+	}
+
+	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	if err != nil {
+		return "", err
+	}
+
+	if path != baseDir && !strings.HasPrefix(path, baseDir+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid cache key %q: resolves outside the cache directory", key)
+	}
+
+	return path, nil
 }
 
 func (f *FileBasedCache) Configure(cacheInfo CacheProvider) error {
@@ -50,7 +72,7 @@ func (*FileBasedCache) List() ([]CacheObjectDetails, error) {
 }
 
 func (*FileBasedCache) Exists(key string) bool {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "warning: error while testing if cache key exists:", err)
@@ -68,7 +90,7 @@ func (*FileBasedCache) Exists(key string) bool {
 }
 
 func (*FileBasedCache) Load(key string) (string, error) {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return "", err
@@ -84,7 +106,7 @@ func (*FileBasedCache) Load(key string) (string, error) {
 }
 
 func (*FileBasedCache) Remove(key string) error {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return err
@@ -98,7 +120,7 @@ func (*FileBasedCache) Remove(key string) error {
 }
 
 func (*FileBasedCache) Store(key string, data string) error {
-	path, err := xdg.CacheFile(filepath.Join("k8sgpt", key))
+	path, err := cachePath(key)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## 📑 Description

Split out from #1712 per review feedback (one narrow fix per PR).

`Exists`, `Load`, `Remove`, and `Store` in the file-based cache all built the cache file path by joining the k8sgpt cache directory with a caller-supplied key, without checking the result stayed inside that directory. A key such as `../../some-file` (e.g. passed to `k8sgpt cache purge`) could resolve outside the intended cache subdirectory.

Added a `cachePath()` helper that resolves the key and rejects any result that escapes the cache base directory, and used it in all four methods.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
`go build ./...`, `go vet ./...`, and the full test suite pass locally.
