### PR TITLE
fix: inspect Gateway Accepted and Programmed by type

### DIFF
--- a/pkg/analyzer/gateway.go
+++ b/pkg/analyzer/gateway.go
@@ -72,14 +72,23 @@ func (GatewayAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			})
 		}
 
-		// Check only the current conditions
-		// TODO: maybe check other statuses Listeners, addresses?
-		if len(gtw.Status.Conditions) > 0 && gtw.Status.Conditions[0].Status != metav1.ConditionTrue {
+		// Inspect Accepted and Programmed by type. Listener/address status is out of scope.
+		for _, cond := range gtw.Status.Conditions {
+			if cond.Type != string(gtwapi.GatewayConditionAccepted) &&
+				cond.Type != string(gtwapi.GatewayConditionProgrammed) {
+				continue
+			}
+			if cond.Status == metav1.ConditionTrue {
+				continue
+			}
 			failures = append(failures, common.Failure{
-				Text: fmt.Sprintf("Gateway '%s/%s' is not accepted. Message: '%s'.",
+				Text: fmt.Sprintf("Gateway '%s/%s' has condition %s=%s, reason %s: %s",
 					gtwNamespace,
 					gtwName,
-					gtw.Status.Conditions[0].Message,
+					cond.Type,
+					cond.Status,
+					cond.Reason,
+					cond.Message,
 				),
 				Sensitive: []common.Sensitive{
 					{

--- a/pkg/analyzer/gateway_test.go
+++ b/pkg/analyzer/gateway_test.go
@@ -208,7 +208,7 @@ func TestStatusGatewayAnalyzer(t *testing.T) {
 		t.Error(err)
 	}
 	var errorFound bool
-	want := "Gateway 'default/foobar' is not accepted. Message: 'An expected message'."
+	want := "Gateway 'default/foobar' has condition Accepted=Unknown, reason Test: An expected message"
 	for _, analysis := range analysisResults {
 		for _, got := range analysis.Error {
 			if want == got.Text {
@@ -223,6 +223,185 @@ func TestStatusGatewayAnalyzer(t *testing.T) {
 	if !errorFound {
 		t.Errorf("Expected message, <%v> , not found in Gateway's analysis results", want)
 	}
+}
+
+func TestProgrammedFalseGatewayAnalyzer(t *testing.T) {
+	ClassName := gtwapi.ObjectName("exists")
+	GatewayClass := BuildGatewayClass(string(ClassName))
+
+	Gateway := BuildGateway(ClassName, metav1.ConditionTrue, nil)
+	Gateway.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(gtwapi.GatewayConditionAccepted),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Accepted",
+			Message: "Gateway accepted",
+		},
+		{
+			Type:    string(gtwapi.GatewayConditionProgrammed),
+			Status:  metav1.ConditionFalse,
+			Reason:  "AddressNotAssigned",
+			Message: "No addresses have been assigned",
+		},
+	}
+
+	scheme := scheme.Scheme
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{
+		&Gateway,
+		&GatewayClass,
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := GatewayAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+
+	want := "Gateway 'default/foobar' has condition Programmed=False, reason AddressNotAssigned: No addresses have been assigned"
+	var errorFound bool
+	for _, analysis := range analysisResults {
+		for _, got := range analysis.Error {
+			if want == got.Text {
+				errorFound = true
+			}
+		}
+	}
+	if !errorFound {
+		t.Errorf("Expected message, <%v> , not found in Gateway's analysis results", want)
+	}
+}
+
+func TestAcceptedFalseNotAtIndexZeroGatewayAnalyzer(t *testing.T) {
+	ClassName := gtwapi.ObjectName("exists")
+	GatewayClass := BuildGatewayClass(string(ClassName))
+
+	Gateway := BuildGateway(ClassName, metav1.ConditionTrue, nil)
+	Gateway.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(gtwapi.GatewayConditionProgrammed),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Programmed",
+			Message: "Configured",
+		},
+		{
+			Type:    string(gtwapi.GatewayConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  "NotAccepted",
+			Message: "Listeners not valid",
+		},
+	}
+
+	scheme := scheme.Scheme
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{
+		&Gateway,
+		&GatewayClass,
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := GatewayAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 1)
+
+	want := "Gateway 'default/foobar' has condition Accepted=False, reason NotAccepted: Listeners not valid"
+	var errorFound bool
+	for _, analysis := range analysisResults {
+		for _, got := range analysis.Error {
+			if want == got.Text {
+				errorFound = true
+			}
+		}
+	}
+	if !errorFound {
+		t.Errorf("Expected message, <%v> , not found in Gateway's analysis results", want)
+	}
+}
+
+func TestAcceptedAndProgrammedTrueGatewayAnalyzer(t *testing.T) {
+	ClassName := gtwapi.ObjectName("exists")
+	GatewayClass := BuildGatewayClass(string(ClassName))
+
+	Gateway := BuildGateway(ClassName, metav1.ConditionTrue, nil)
+	Gateway.Status.Conditions = []metav1.Condition{
+		{
+			Type:    string(gtwapi.GatewayConditionAccepted),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Accepted",
+			Message: "Gateway accepted",
+		},
+		{
+			Type:    string(gtwapi.GatewayConditionProgrammed),
+			Status:  metav1.ConditionTrue,
+			Reason:  "Programmed",
+			Message: "Configured",
+		},
+	}
+
+	scheme := scheme.Scheme
+	err := gtwapi.Install(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	err = apiextensionsv1.AddToScheme(scheme)
+	if err != nil {
+		t.Error(err)
+	}
+	objects := []runtime.Object{
+		&Gateway,
+		&GatewayClass,
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+
+	analyzerInstance := GatewayAnalyzer{}
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			CtrlClient: fakeClient,
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+	analysisResults, err := analyzerInstance.Analyze(config)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, len(analysisResults), 0)
 }
 
 func TestGatewayAnalyzerLabelSelectorFiltering(t *testing.T) {


### PR DESCRIPTION
Closes #1736

## 📑 Description

The Gateway analyzer treated `status.conditions[0]` as Accepted and hard-coded the failure text as `"is not accepted"`. Gateway API conditions are a map keyed by type (`Accepted` and `Programmed`); implementations must not reorder them, so the default order is `[Accepted, Programmed]`. A Gateway that is Accepted but `Programmed=False` was therefore missed, and a non-Accepted condition at index 0 was mislabeled as "not accepted".

This PR looks up `Accepted` and `Programmed` by type, reports each non-True condition by name, and leaves Listener/address status out of scope.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1 -run 'Gateway'` — passes
- `go vet ./pkg/analyzer/` — clean
- `gofmt` — clean
- `git diff --check` — clean

Regression tests added:
- `TestProgrammedFalseGatewayAnalyzer` — default order `[Accepted=True, Programmed=False]` is reported
- `TestAcceptedFalseNotAtIndexZeroGatewayAnalyzer` — Accepted not at index 0 is still reported
- `TestAcceptedAndProgrammedTrueGatewayAnalyzer` — both True produces no result