### PR TITLE
fix: ignore in-progress Deployment replica mismatches

### DIFF
--- a/pkg/analyzer/deployment.go
+++ b/pkg/analyzer/deployment.go
@@ -56,7 +56,7 @@ func (d DeploymentAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 
 	for _, deployment := range deployments.Items {
 		var failures []common.Failure
-		if deployment.Spec.Replicas != nil && *deployment.Spec.Replicas != deployment.Status.ReadyReplicas {
+		if shouldReportReplicaMismatch(deployment) {
 			if deployment.Status.Replicas > *deployment.Spec.Replicas {
 				doc := apiDoc.GetApiDocV2("spec.replicas")
 
@@ -140,4 +140,36 @@ func (d DeploymentAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) 
 	}
 
 	return a.Results, nil
+}
+
+// shouldReportReplicaMismatch ignores stale status and healthy in-progress rollouts.
+func shouldReportReplicaMismatch(deployment appsv1.Deployment) bool {
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas == deployment.Status.ReadyReplicas {
+		return false
+	}
+
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		return false
+	}
+
+	if hasHealthyProgress(deployment.Status.Conditions) {
+		return false
+	}
+
+	return true
+}
+
+func hasHealthyProgress(conditions []appsv1.DeploymentCondition) bool {
+	progressing := false
+	available := false
+	for _, condition := range conditions {
+		switch condition.Type {
+		case appsv1.DeploymentProgressing:
+			progressing = condition.Status == corev1.ConditionTrue
+		case appsv1.DeploymentAvailable:
+			available = condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return progressing && available
 }

--- a/pkg/analyzer/deployment_test.go
+++ b/pkg/analyzer/deployment_test.go
@@ -365,3 +365,100 @@ func TestDeploymentAnalyzerProgressingTrueNotReported(t *testing.T) {
 	}
 	assert.Equal(t, len(analysisResults), 0)
 }
+
+func TestDeploymentAnalyzerInProgressRolloutsNotReported(t *testing.T) {
+	newDeployment := func(name string, generation int64, status appsv1.DeploymentStatus) *appsv1.Deployment {
+		replicas := int32(3)
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  "default",
+				Generation: generation,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Template: v1.PodTemplateSpec{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{{
+							Name:  "example-container",
+							Image: "nginx",
+						}},
+					},
+				},
+			},
+			Status: status,
+		}
+	}
+
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+	}{
+		{
+			name: "healthy rollout in progress",
+			deployment: newDeployment("rollout", 1, appsv1.DeploymentStatus{
+				Replicas:           3,
+				ReadyReplicas:      2,
+				AvailableReplicas:  2,
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: v1.ConditionTrue,
+					},
+				},
+			}),
+		},
+		{
+			name: "scaling in progress",
+			deployment: newDeployment("scaling", 2, appsv1.DeploymentStatus{
+				Replicas:           4,
+				ReadyReplicas:      2,
+				AvailableReplicas:  2,
+				ObservedGeneration: 2,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: v1.ConditionTrue,
+					},
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: v1.ConditionTrue,
+					},
+				},
+			}),
+		},
+		{
+			name: "controller has not observed the latest generation",
+			deployment: newDeployment("stale", 2, appsv1.DeploymentStatus{
+				Replicas:           2,
+				ReadyReplicas:      1,
+				AvailableReplicas:  1,
+				ObservedGeneration: 1,
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(test.deployment)
+			config := common.Analyzer{
+				Client: &kubernetes.Client{
+					Client: clientset,
+				},
+				Context:   context.Background(),
+				Namespace: "default",
+			}
+
+			analysisResults, err := (DeploymentAnalyzer{}).Analyze(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, len(analysisResults), 0)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1742

## 📑 Description

The Deployment analyzer reports replica mismatches during healthy rollouts because it compares `spec.replicas` with `status.readyReplicas` without checking status freshness or progress state. This change skips that mismatch while the controller has not observed the latest generation or the Deployment reports both `Available=True` and `Progressing=True`. Existing `Progressing=False` / `ProgressDeadlineExceeded` failures remain reported.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1 -run 'TestDeploymentAnalyzer'` — passes
- `go test ./pkg/analyzer/ -count=1` — passes
- `go vet ./pkg/analyzer/` — clean
- `gofmt` — clean
- `git diff --check` — clean

Regression tests added:
- `TestDeploymentAnalyzerInProgressRolloutsNotReported`
- Existing `TestDeploymentAnalyzerProgressDeadlineExceeded` remains in place
