### PR TITLE
fix: scope NetworkPolicy pod lookup to policy namespace

### DIFF
--- a/pkg/analyzer/netpol.go
+++ b/pkg/analyzer/netpol.go
@@ -69,7 +69,7 @@ func (NetworkPolicyAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error)
 			})
 		} else {
 			// Check if policy is not applied to any pods
-			podList, err := util.GetPodListByLabels(a.Client.GetClient(), a.Namespace, policy.Spec.PodSelector.MatchLabels)
+			podList, err := util.GetPodListByLabels(a.Client.GetClient(), policy.Namespace, policy.Spec.PodSelector.MatchLabels)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/analyzer/netpol_test.go
+++ b/pkg/analyzer/netpol_test.go
@@ -134,6 +134,59 @@ func TestNetpolWithPod(t *testing.T) {
 	assert.Equal(t, len(results), 0)
 }
 
+func TestNetpolNoPodsUsesPolicyNamespace(t *testing.T) {
+	clientset := fake.NewSimpleClientset(
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker-policy",
+				Namespace: "team-a",
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app": "worker",
+					},
+				},
+			},
+		},
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "worker",
+				Namespace: "team-b",
+				Labels: map[string]string{
+					"app": "worker",
+				},
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "worker",
+						Image: "example",
+					},
+				},
+			},
+		},
+	)
+
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: clientset,
+		},
+		Context: context.Background(),
+	}
+
+	analyzer := NetworkPolicyAnalyzer{}
+	results, err := analyzer.Analyze(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected one result for the policy in its own namespace, got %v", results)
+	}
+	assert.Equal(t, results[0].Name, "team-a/worker-policy")
+}
+
 func TestNetpolNoPodsNamespaceFiltering(t *testing.T) {
 	clientset := fake.NewSimpleClientset(
 		&networkingv1.NetworkPolicy{


### PR DESCRIPTION
Closes #1746

## 📑 Description

When NetworkPolicy analysis runs cluster-wide, the analyzer can match a policy in one namespace against a same-label Pod in another namespace. This suppresses the diagnostic that the policy selects no Pods in its own namespace because the Pod lookup uses the analysis namespace instead of the policy namespace.

This change scopes the Pod lookup to `policy.Namespace` and adds a fake-client regression test covering a `team-a` policy with only a same-label `team-b` Pod. Support for `matchExpressions` is intentionally outside this change.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:

- `go test ./pkg/analyzer/ -count=1 -run '^TestNetpol'` — passes
- `go test ./pkg/analyzer/ -count=1` — passes
- `go test ./... -count=1` — passes
- `go vet ./pkg/analyzer/` — clean
- `gofmt -w pkg/analyzer/netpol.go pkg/analyzer/netpol_test.go` — clean
- `git diff --check` — clean

Regression tests added:

- `TestNetpolNoPodsUsesPolicyNamespace` — verifies that a same-label Pod in another namespace does not satisfy a NetworkPolicy's selector.
