### PR TITLE
fix: honour K8SGPT_BACKEND on every serve start

### DIFF
--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -59,6 +59,9 @@ var ServeCmd = &cobra.Command{
 			color.Red("Error: %v", err)
 			os.Exit(1)
 		}
+		// K8SGPT_BACKEND must be honoured on every start, not only the first.
+		backend = resolveBackend(cmd.Flags().Changed("backend"), backend)
+
 		var aiProvider *ai.AIProvider
 		if len(configAI.Providers) == 0 {
 			// we validate and set temperature for our backend
@@ -234,6 +237,20 @@ var ServeCmd = &cobra.Command{
 		// Wait for both servers to exit
 		select {}
 	},
+}
+
+// resolveBackend returns the backend name to look up in the configuration. The
+// config written on the first start makes the env block in ServeCmd unreachable
+// on later starts, so K8SGPT_BACKEND is read here too. An explicit --backend
+// still takes precedence.
+func resolveBackend(flagChanged bool, current string) string {
+	if flagChanged {
+		return current
+	}
+	if envBackend := os.Getenv("K8SGPT_BACKEND"); envBackend != "" {
+		return envBackend
+	}
+	return current
 }
 
 func providerFromEnv(

--- a/cmd/serve/serve_test.go
+++ b/cmd/serve/serve_test.go
@@ -67,3 +67,29 @@ func TestProviderFromEnvReturnsFalseWhenUnset(t *testing.T) {
 		t.Fatalf("expected no provider, got %#v", provider)
 	}
 }
+
+// A restart with a config that already holds the provider must still honour
+// K8SGPT_BACKEND; before the fix it fell back to the "openai" flag default.
+func TestResolveBackendPrefersEnvOverFlagDefault(t *testing.T) {
+	t.Setenv("K8SGPT_BACKEND", "google")
+
+	if got := resolveBackend(false, "openai"); got != "google" {
+		t.Fatalf("expected K8SGPT_BACKEND to override the unchanged flag default, got %q", got)
+	}
+}
+
+func TestResolveBackendKeepsExplicitFlag(t *testing.T) {
+	t.Setenv("K8SGPT_BACKEND", "google")
+
+	if got := resolveBackend(true, "localai"); got != "localai" {
+		t.Fatalf("expected an explicitly set --backend to win over the environment, got %q", got)
+	}
+}
+
+func TestResolveBackendKeepsDefaultWhenEnvUnset(t *testing.T) {
+	t.Setenv("K8SGPT_BACKEND", "")
+
+	if got := resolveBackend(false, "openai"); got != "openai" {
+		t.Fatalf("expected the flag default to be kept when K8SGPT_BACKEND is unset, got %q", got)
+	}
+}


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Relates to #1074

## 📑 Description

`serve` reads `K8SGPT_BACKEND` only when the config holds no providers yet, and
it persists the provider it resolves on first start. Where that config outlives
the process, as it does under the operator which points `XDG_CONFIG_HOME` at a
volume that survives container restarts, every later start finds a populated
config, skips the env block, and leaves `backend` at the `--backend` default of
`openai`. The lookup then fails against a config that never contained `openai`:

```
Error: AI provider openai not specified in configuration. Please run k8sgpt auth
```

So a single container restart breaks the deployment permanently, and deleting
the pod is the only recovery, since the operator exposes no way to pass
`--backend`. It also only reproduces on the *second* start, which is why a clean
install looks fine. Matches the operator report in #1074 (comment of
2026-04-12).

Verified on `main` (05247a8) with `XDG_CONFIG_HOME` set and
`K8SGPT_BACKEND=google`:

```
run 1  starts, writes provider "google" to the config
run 2  Error: AI provider openai not specified in configuration   (exit 1)
```

With this change run 2 starts normally. `--backend openai` still overrides the
environment, and with no env set the error is byte-identical to before, so
precedence is unchanged.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

`TestResolveBackendPrefersEnvOverFlagDefault` fails on `main` with `got "openai"`
and passes with the fix. Two further tests pin the explicit-flag and unset-env
cases so the precedence cannot regress quietly.
