### PR TITLE
fix: report ReplicaFailure regardless of replica count

### DIFF
--- a/pkg/analyzer/rs.go
+++ b/pkg/analyzer/rs.go
@@ -42,20 +42,19 @@ func (ReplicaSetAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 	for _, rs := range list.Items {
 		var failures []common.Failure
 
-		// Check for empty rs
-		if rs.Status.Replicas == 0 {
-
-			// Check through container status to check for crashes
-			for _, rsStatus := range rs.Status.Conditions {
-				if rsStatus.Type == "ReplicaFailure" && rsStatus.Reason == "FailedCreate" {
-					failures = append(failures, common.Failure{
-						Text:      rsStatus.Message,
-						Sensitive: []common.Sensitive{},
-					})
-
-				}
+		// ReplicaFailure is reported by the ReplicaSet controller when a Pod
+		// fails to be created, independent of how many Pods already exist.
+		// Evaluate it regardless of the current replica count so a partially
+		// fulfilled ReplicaSet can still surface a failed scale-up.
+		for _, rsStatus := range rs.Status.Conditions {
+			if rsStatus.Type == "ReplicaFailure" && rsStatus.Reason == "FailedCreate" {
+				failures = append(failures, common.Failure{
+					Text:      rsStatus.Message,
+					Sensitive: []common.Sensitive{},
+				})
 			}
 		}
+
 		if len(failures) > 0 {
 			preAnalysis[fmt.Sprintf("%s/%s", rs.Namespace, rs.Name)] = common.PreAnalysis{
 				ReplicaSet:     rs,

--- a/pkg/analyzer/rs_test.go
+++ b/pkg/analyzer/rs_test.go
@@ -199,3 +199,58 @@ func TestReplicaSetAnalyzerLabelSelectorFiltering(t *testing.T) {
 	require.Equal(t, 1, len(results))
 	require.Equal(t, "default/ReplicaSet1", results[0].Name)
 }
+
+// TestReplicaSetAnalyzerReplicaFailureWithExistingReplicas covers the case
+// where a ReplicaSet already has some replicas but is failing to create
+// additional Pods. ReplicaFailure must be reported regardless of the replica
+// count (see issue #1748).
+func TestReplicaSetAnalyzerReplicaFailureWithExistingReplicas(t *testing.T) {
+	config := common.Analyzer{
+		Client: &kubernetes.Client{
+			Client: fake.NewSimpleClientset(
+				&appsv1.ReplicaSet{
+					// Partially fulfilled ReplicaSet with a failed scale-up:
+					// one replica exists, but the controller reports
+					// ReplicaFailure=True/FailedCreate. This must be reported.
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "replicaset-failed-scale-up",
+						Namespace: "default",
+					},
+					Status: appsv1.ReplicaSetStatus{
+						Replicas: 1,
+						Conditions: []appsv1.ReplicaSetCondition{
+							{
+								Type:    appsv1.ReplicaSetReplicaFailure,
+								Reason:  "FailedCreate",
+								Message: "quota exceeded",
+							},
+						},
+					},
+				},
+				&appsv1.ReplicaSet{
+					// Healthy partially available ReplicaSet: some replicas are
+					// running and there is no ReplicaFailure condition. This is
+					// a control case and must not be reported.
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "replicaset-healthy-partial",
+						Namespace: "default",
+					},
+					Status: appsv1.ReplicaSetStatus{
+						Replicas: 1,
+					},
+				},
+			),
+		},
+		Context:   context.Background(),
+		Namespace: "default",
+	}
+
+	rsAnalyzer := ReplicaSetAnalyzer{}
+	results, err := rsAnalyzer.Analyze(config)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(results))
+	require.Equal(t, "default/replicaset-failed-scale-up", results[0].Name)
+	require.Equal(t, 1, len(results[0].Error))
+	require.Equal(t, "quota exceeded", results[0].Error[0].Text)
+}


### PR DESCRIPTION
## 📑 Description

The ReplicaSet analyzer only inspected `status.conditions` inside `if rs.Status.Replicas == 0`, so a partially fulfilled ReplicaSet that was failing to create additional Pods (`status.replicas > 0` together with `ReplicaFailure=True`/`FailedCreate`) suppressed the failure and produced no result.

`ReplicaFailure` is reported by the ReplicaSet controller when a Pod fails to be created, independent of how many Pods already exist. This change evaluates `ReplicaFailure=True`/`FailedCreate` independently of the replica count. Scope is kept to the `FailedCreate` reason as a focused first step.

Closes #1748

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1` — passes
- `go vet ./pkg/analyzer/` — clean
- `gofmt` — clean
- `git diff --check` — clean

Regression tests added:
- `TestReplicaSetAnalyzerReplicaFailureWithExistingReplicas` covers a ReplicaSet with one existing replica plus a failed scale-up (`ReplicaFailure=True`/`FailedCreate`), and a healthy partially available control case.