### PR TITLE
fix: scope Service events to their object identity

### DIFF
--- a/pkg/analyzer/service.go
+++ b/pkg/analyzer/service.go
@@ -114,7 +114,7 @@ func (ServiceAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			}
 		}
 		// fetch event
-		events, err := a.Client.GetClient().CoreV1().Events(a.Namespace).List(a.Context,
+		events, err := a.Client.GetClient().CoreV1().Events(ep.Namespace).List(a.Context,
 			metav1.ListOptions{
 				FieldSelector: "involvedObject.name=" + ep.Name,
 			})
@@ -123,7 +123,7 @@ func (ServiceAnalyzer) Analyze(a common.Analyzer) ([]common.Result, error) {
 			return nil, err
 		}
 		for _, event := range events.Items {
-			if event.Type != "Normal" {
+			if event.Type != "Normal" && event.InvolvedObject.Kind == kind {
 				failures = append(failures, common.Failure{
 					Text: fmt.Sprintf("Service %s/%s has event %s", ep.Namespace, ep.Name, event.Message),
 				})

--- a/pkg/analyzer/service_test.go
+++ b/pkg/analyzer/service_test.go
@@ -402,3 +402,76 @@ func TestServiceAnalyzerLabelSelectorFiltering(t *testing.T) {
 	require.Equal(t, 1, len(results))
 	require.Equal(t, "default/Endpoint1", results[0].Name)
 }
+
+func TestServiceAnalyzerIgnoresEventsForOtherKinds(t *testing.T) {
+	clientSet := fake.NewSimpleClientset(
+		&v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "api",
+				Namespace: "default",
+			},
+			Subsets: []v1.EndpointSubset{{
+				Addresses: []v1.EndpointAddress{{
+					IP: "10.0.0.1",
+				}},
+			}},
+		},
+		&v1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-warning",
+				Namespace: "default",
+			},
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Pod",
+				Name:      "api",
+				Namespace: "default",
+			},
+			Type:    "Warning",
+			Message: "unrelated Pod warning",
+		},
+	)
+
+	results, err := (ServiceAnalyzer{}).Analyze(common.Analyzer{
+		Client:    &kubernetes.Client{Client: clientSet},
+		Context:   context.Background(),
+		Namespace: "default",
+	})
+	require.NoError(t, err)
+	require.Empty(t, results)
+}
+
+func TestServiceAnalyzerScopesEventsToEndpointNamespace(t *testing.T) {
+	clientSet := fake.NewSimpleClientset(
+		&v1.Endpoints{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "api",
+				Namespace: "team-a",
+			},
+			Subsets: []v1.EndpointSubset{{
+				Addresses: []v1.EndpointAddress{{
+					IP: "10.0.0.1",
+				}},
+			}},
+		},
+		&v1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service-warning",
+				Namespace: "team-b",
+			},
+			InvolvedObject: v1.ObjectReference{
+				Kind:      "Service",
+				Name:      "api",
+				Namespace: "team-b",
+			},
+			Type:    "Warning",
+			Message: "unrelated Service warning",
+		},
+	)
+
+	results, err := (ServiceAnalyzer{}).Analyze(common.Analyzer{
+		Client:  &kubernetes.Client{Client: clientSet},
+		Context: context.Background(),
+	})
+	require.NoError(t, err)
+	require.Empty(t, results)
+}


### PR DESCRIPTION
Closes #1752

## 📑 Description

The Service analyzer lists Events using the analysis namespace and only matches `involvedObject.name`. During cluster-wide analysis, this can attach a Warning Event from another namespace or another Kubernetes kind to a Service with the same name.

This PR scopes the Event list to the Endpoint namespace and requires `involvedObject.kind == "Service"` before adding the failure. The existing name selector remains in place, so the Service Event identity is matched without changing the shared Event helper or other analyzers.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1` — passes
- `go test ./... -count=1` — passes
- `go vet ./pkg/analyzer/` — clean
- `gofmt` — clean
- `git diff --check` — clean

Regression tests added:
- `TestServiceAnalyzerIgnoresEventsForOtherKinds` — a same-name Pod Warning Event does not create a Service result
- `TestServiceAnalyzerScopesEventsToEndpointNamespace` — a same-name Service Warning Event in another namespace does not create a result during cluster-wide analysis
