### PR TITLE
fix: resolve ClusterRole references in RoleBindings

### DIFF
--- a/pkg/analyzer/security.go
+++ b/pkg/analyzer/security.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -115,17 +116,32 @@ func analyzeRoleBindings(a common.Analyzer) ([]common.Result, error) {
 
 	for _, rb := range rbs.Items {
 		var failures []common.Failure
+		var rules []rbacv1.PolicyRule
+		roleKind := rb.RoleRef.Kind
 
 		// Check for wildcards in role references
-		role, err := a.Client.GetClient().RbacV1().Roles(rb.Namespace).Get(a.Context, rb.RoleRef.Name, metav1.GetOptions{})
-		if err != nil {
+		switch roleKind {
+		case "", "Role":
+			role, err := a.Client.GetClient().RbacV1().Roles(rb.Namespace).Get(a.Context, rb.RoleRef.Name, metav1.GetOptions{})
+			if err != nil {
+				continue
+			}
+			rules = role.Rules
+			roleKind = "Role"
+		case "ClusterRole":
+			clusterRole, err := a.Client.GetClient().RbacV1().ClusterRoles().Get(a.Context, rb.RoleRef.Name, metav1.GetOptions{})
+			if err != nil {
+				continue
+			}
+			rules = clusterRole.Rules
+		default:
 			continue
 		}
 
-		for _, rule := range role.Rules {
+		for _, rule := range rules {
 			if containsWildcard(rule.Verbs) || containsWildcard(rule.Resources) {
 				failures = append(failures, common.Failure{
-					Text:      fmt.Sprintf("RoleBinding %s references Role %s which contains wildcard permissions - this is not recommended for security best practices", rb.Name, role.Name),
+					Text:      fmt.Sprintf("RoleBinding %s references %s %s which contains wildcard permissions - this is not recommended for security best practices", rb.Name, roleKind, rb.RoleRef.Name),
 					Sensitive: []common.Sensitive{},
 				})
 			}

--- a/pkg/analyzer/security_clusterrole_audit_test.go
+++ b/pkg/analyzer/security_clusterrole_audit_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2024 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyzer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/kubernetes"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestAnalyzeRoleBindingsResolvesClusterRoleReferences(t *testing.T) {
+	const namespace = "team-a"
+
+	tests := []struct {
+		name             string
+		clusterRoleRules []rbacv1.PolicyRule
+		roleRules        []rbacv1.PolicyRule
+		expectedResults  int
+	}{
+		{
+			name: "reports wildcard permissions from cluster role",
+			clusterRoleRules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"*"},
+				Resources: []string{"pods"},
+			}},
+			expectedResults: 1,
+		},
+		{
+			name: "does not inspect same-named namespaced role",
+			clusterRoleRules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"get"},
+				Resources: []string{"pods"},
+			}},
+			roleRules: []rbacv1.PolicyRule{{
+				Verbs:     []string{"*"},
+				Resources: []string{"secrets"},
+			}},
+			expectedResults: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clusterRole := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: "shared-access"},
+				Rules:      tt.clusterRoleRules,
+			}
+			roleBinding := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "team-binding", Namespace: namespace},
+				RoleRef: rbacv1.RoleRef{
+					Kind: "ClusterRole",
+					Name: "shared-access",
+				},
+			}
+
+			objects := []runtime.Object{clusterRole, roleBinding}
+			if tt.roleRules != nil {
+				objects = append(objects, &rbacv1.Role{
+					ObjectMeta: metav1.ObjectMeta{Name: "shared-access", Namespace: namespace},
+					Rules:      tt.roleRules,
+				})
+			}
+
+			client := fake.NewSimpleClientset(objects...)
+			results, err := analyzeRoleBindings(common.Analyzer{
+				Client:    &kubernetes.Client{Client: client},
+				Context:   context.Background(),
+				Namespace: namespace,
+			})
+
+			require.NoError(t, err)
+			require.Len(t, results, tt.expectedResults)
+			if tt.expectedResults == 1 {
+				require.Equal(t, "Security/RoleBinding", results[0].Kind)
+				require.Equal(t, "team-a/team-binding", results[0].Name)
+				require.Contains(t, results[0].Error[0].Text, "ClusterRole shared-access")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1754

## 📑 Description

The Security analyzer always resolved RoleBinding references through the
namespaced Roles API and ignored roleRef.kind.

This caused ClusterRole references to be silently skipped when no same-named
Role existed, and caused an unrelated same-named Role to be analyzed instead.

This change selects the namespaced Role or cluster-scoped ClusterRole lookup
according to roleRef.kind. It also adds fake-client regressions for both cases.

ClusterRoleBinding and other analyzers are intentionally out of scope.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:

- `go test ./pkg/analyzer/ -count=1`
- `go test ./... -count=1`
- `go vet ./pkg/analyzer/`
- `go vet ./...`
- `gofmt`
- `git diff --check`
