### PR TITLE
fix: stop reporting local StorageClasses as deprecated

### DIFF
--- a/pkg/analyzer/storage.go
+++ b/pkg/analyzer/storage.go
@@ -68,14 +68,6 @@ func analyzeStorageClasses(a common.Analyzer) ([]common.Result, error) {
 	for _, sc := range scs.Items {
 		var failures []common.Failure
 
-		// Check for deprecated storage classes
-		if sc.Provisioner == "kubernetes.io/no-provisioner" {
-			failures = append(failures, common.Failure{
-				Text:      fmt.Sprintf("StorageClass %s uses deprecated provisioner 'kubernetes.io/no-provisioner'", sc.Name),
-				Sensitive: []common.Sensitive{},
-			})
-		}
-
 		// Check for default storage class
 		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
 			// Check if there are multiple default storage classes

--- a/pkg/analyzer/storage_test.go
+++ b/pkg/analyzer/storage_test.go
@@ -36,17 +36,17 @@ func TestStorageAnalyzer(t *testing.T) {
 		expectedErrors int
 	}{
 		{
-			name:      "Deprecated StorageClass",
+			name:      "Local StorageClass with no-provisioner",
 			namespace: "default",
 			storageClasses: []storagev1.StorageClass{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "deprecated-sc",
+						Name: "local-sc",
 					},
 					Provisioner: "kubernetes.io/no-provisioner",
 				},
 			},
-			expectedErrors: 1,
+			expectedErrors: 0,
 		},
 		{
 			name:      "Multiple Default StorageClasses",


### PR DESCRIPTION
Closes #1774

## 📑 Description

The Storage analyzer reports every StorageClass whose provisioner is `kubernetes.io/no-provisioner` as using a deprecated provisioner. That value is the standard marker for StorageClasses that do not support dynamic provisioning, used with local (static) volumes. It is not one of the in-tree provisioners deprecated by CSI migration. A user with a legitimate local StorageClass gets an error that misattributes their setup, and the false positive also consumes an AI explanation.

This change removes that check. A local StorageClass is now reported only for real issues, such as being one of several default StorageClasses.

## ✅ Checks

- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

Verified locally:
- `go test ./pkg/analyzer/ -count=1 -run TestStorageAnalyzer` passes
- `go test ./pkg/analyzer/ -count=1` passes
- `go vet ./pkg/analyzer/` clean
- `gofmt` clean
- `go build ./...` clean

The existing Deprecated StorageClass test case was turned into a regression case named Local StorageClass with no-provisioner that asserts no error. It fails on main, where the analyzer still reports the deprecated error, and passes with this change.

Note: drafted with AI assistance; the change and tests were verified locally.
