### PR TITLE
fix: anonymise resource names in event-derived failures

### DIFF
--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -537,27 +539,93 @@ func resourceSensitive(name string) []common.Sensitive {
 	return sensitive
 }
 
-func maskText(text string, sets ...[]common.Sensitive) string {
+// sensitiveMapping merges the pairs the analyzers declared with the ones
+// derived from the result's identity into a single deduplicated set, ordered
+// longest unmasked value first.
+//
+// The values overlap. A result named "prod/api-prod" derives both "prod" and
+// "api-prod", and a declared value can contain a derived one the same way.
+// Applying the pairs one at a time in declaration order masks the "prod"
+// suffix inside the pod name first, after which "api-prod" no longer matches
+// and "api-" is left in the prompt. Ordering longest first and replacing in a
+// single pass (see maskText) matches the complete identifier instead.
+//
+// Deduplicating on the unmasked value also keeps one identifier from having
+// two different masks, which would only be reversed by whichever pair the
+// unmasking happened to reach first.
+func sensitiveMapping(sets ...[]common.Sensitive) []common.Sensitive {
+	seen := make(map[string]bool)
+	var mapping []common.Sensitive
 	for _, set := range sets {
 		for _, s := range set {
-			text = util.ReplaceIfMatch(text, s.Unmasked, s.Masked)
-		}
-	}
-	return text
-}
-
-func unmaskText(text string, sets ...[]common.Sensitive) string {
-	for _, set := range sets {
-		for _, s := range set {
-			// strings.ReplaceAll with an empty needle inserts the replacement
-			// between every character.
-			if s.Masked == "" {
+			// An empty value matches at every position and would shred the
+			// text in either direction.
+			if s.Unmasked == "" || s.Masked == "" || seen[s.Unmasked] {
 				continue
 			}
-			text = strings.ReplaceAll(text, s.Masked, s.Unmasked)
+			seen[s.Unmasked] = true
+			mapping = append(mapping, s)
 		}
 	}
-	return text
+	sort.SliceStable(mapping, func(i, j int) bool {
+		return len(mapping[i].Unmasked) > len(mapping[j].Unmasked)
+	})
+	return mapping
+}
+
+// replaceLongestFirst rewrites every needle in one left-to-right pass, so a
+// replacement it just wrote is never itself rewritten by a later pair.
+//
+// Go's regexp prefers the earliest alternative that matches at a position, so
+// listing the needles longest first is what makes a complete identifier win
+// over a shorter one nested in it. The needles are literal values, not
+// patterns, hence QuoteMeta: node names are routinely FQDNs whose "." would
+// otherwise match any character, and masks are base64 that can contain "+"
+// and "/".
+func replaceLongestFirst(text string, needles []string, replacement map[string]string, suffix string) string {
+	if len(needles) == 0 {
+		return text
+	}
+	alternatives := make([]string, 0, len(needles))
+	for _, needle := range needles {
+		alternatives = append(alternatives, regexp.QuoteMeta(needle))
+	}
+	re := regexp.MustCompile(`(?:` + strings.Join(alternatives, "|") + `)` + suffix)
+	return re.ReplaceAllStringFunc(text, func(match string) string {
+		return replacement[match]
+	})
+}
+
+func maskText(text string, mapping []common.Sensitive) string {
+	needles := make([]string, 0, len(mapping))
+	masked := make(map[string]string, len(mapping))
+	for _, s := range mapping {
+		needles = append(needles, s.Unmasked)
+		masked[s.Unmasked] = s.Masked
+	}
+	// The trailing boundary preserves the behaviour of util.ReplaceIfMatch: a
+	// value is redacted where it ends a word, not in the middle of a longer
+	// identifier that merely starts with it.
+	return replaceLongestFirst(text, needles, masked, `\b`)
+}
+
+func unmaskText(text string, mapping []common.Sensitive) string {
+	ordered := make([]common.Sensitive, len(mapping))
+	copy(ordered, mapping)
+	// Longest first again, this time on the masks, since an analyzer is free
+	// to declare a mask that contains another one.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return len(ordered[i].Masked) > len(ordered[j].Masked)
+	})
+
+	needles := make([]string, 0, len(ordered))
+	unmasked := make(map[string]string, len(ordered))
+	for _, s := range ordered {
+		needles = append(needles, s.Masked)
+		unmasked[s.Masked] = s.Unmasked
+	}
+	// No boundary on the way back: base64 masks can end in "=".
+	return replaceLongestFirst(text, needles, unmasked, "")
 }
 
 func (a *Analysis) GetAIResults(output string, anonymize bool) error {
@@ -580,10 +648,16 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 
 		// Analyzers only mask what they explicitly declare in Failure.Sensitive,
 		// and most declare nothing for event-derived failures, so mask the
-		// resource's own identity as well. See resourceSensitive.
-		var identity []common.Sensitive
+		// resource's own identity as well. See resourceSensitive. One mapping
+		// covers the whole result in both directions, so overlapping values
+		// resolve the same way going out and coming back.
+		var mapping []common.Sensitive
 		if anonymize {
-			identity = resourceSensitive(analysis.Name)
+			sets := make([][]common.Sensitive, 0, len(analysis.Error)+1)
+			for _, failure := range analysis.Error {
+				sets = append(sets, failure.Sensitive)
+			}
+			mapping = sensitiveMapping(append(sets, resourceSensitive(analysis.Name))...)
 		}
 
 		if bar != nil && verbose {
@@ -592,7 +666,7 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 
 		for _, failure := range analysis.Error {
 			if anonymize {
-				failure.Text = maskText(failure.Text, identity, failure.Sensitive)
+				failure.Text = maskText(failure.Text, mapping)
 			}
 			texts = append(texts, failure.Text)
 		}
@@ -619,10 +693,7 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 		}
 
 		if anonymize {
-			for _, failure := range analysis.Error {
-				result = unmaskText(result, failure.Sensitive)
-			}
-			result = unmaskText(result, identity)
+			result = unmaskText(result, mapping)
 		}
 
 		analysis.Details = result

--- a/pkg/analysis/analysis.go
+++ b/pkg/analysis/analysis.go
@@ -508,6 +508,58 @@ func (a *Analysis) executeAnalyzer(analyzer common.IAnalyzer, filter string, ana
 	<-semaphore
 }
 
+// resourceSensitive derives masking pairs from a result's own identity.
+//
+// Result.Name is the path the analyzer keyed the resource on: "namespace/name"
+// for namespaced resources, "namespace/pod/container" for the container-level
+// analyzers, and a bare name for cluster-scoped ones such as Node. Those
+// segments are exactly the identifiers that appear verbatim inside Kubernetes
+// event messages and status conditions, which analyzers copy straight into
+// Failure.Text with an empty Failure.Sensitive, so they reach the AI provider
+// unmasked even under --anonymize (issue #560).
+//
+// Deriving them here covers every analyzer at once, including the ones that
+// never populated Sensitive and any added later. Analyzers that do declare
+// their own entries keep working: the two sets compose.
+func resourceSensitive(name string) []common.Sensitive {
+	var sensitive []common.Sensitive
+	for _, segment := range strings.Split(name, "/") {
+		// Masking the empty string would match everywhere and shred the text
+		// in both directions.
+		if segment == "" {
+			continue
+		}
+		sensitive = append(sensitive, common.Sensitive{
+			Unmasked: segment,
+			Masked:   util.MaskString(segment),
+		})
+	}
+	return sensitive
+}
+
+func maskText(text string, sets ...[]common.Sensitive) string {
+	for _, set := range sets {
+		for _, s := range set {
+			text = util.ReplaceIfMatch(text, s.Unmasked, s.Masked)
+		}
+	}
+	return text
+}
+
+func unmaskText(text string, sets ...[]common.Sensitive) string {
+	for _, set := range sets {
+		for _, s := range set {
+			// strings.ReplaceAll with an empty needle inserts the replacement
+			// between every character.
+			if s.Masked == "" {
+				continue
+			}
+			text = strings.ReplaceAll(text, s.Masked, s.Unmasked)
+		}
+	}
+	return text
+}
+
 func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 	if len(a.Results) == 0 {
 		return nil
@@ -526,15 +578,21 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 	for index, analysis := range a.Results {
 		var texts []string
 
+		// Analyzers only mask what they explicitly declare in Failure.Sensitive,
+		// and most declare nothing for event-derived failures, so mask the
+		// resource's own identity as well. See resourceSensitive.
+		var identity []common.Sensitive
+		if anonymize {
+			identity = resourceSensitive(analysis.Name)
+		}
+
 		if bar != nil && verbose {
 			bar.Describe(fmt.Sprintf("Analyzing %s", analysis.Kind))
 		}
 
 		for _, failure := range analysis.Error {
 			if anonymize {
-				for _, s := range failure.Sensitive {
-					failure.Text = util.ReplaceIfMatch(failure.Text, s.Unmasked, s.Masked)
-				}
+				failure.Text = maskText(failure.Text, identity, failure.Sensitive)
 			}
 			texts = append(texts, failure.Text)
 		}
@@ -562,10 +620,9 @@ func (a *Analysis) GetAIResults(output string, anonymize bool) error {
 
 		if anonymize {
 			for _, failure := range analysis.Error {
-				for _, s := range failure.Sensitive {
-					result = strings.ReplaceAll(result, s.Masked, s.Unmasked)
-				}
+				result = unmaskText(result, failure.Sensitive)
 			}
+			result = unmaskText(result, identity)
 		}
 
 		analysis.Details = result

--- a/pkg/analysis/anonymize_test.go
+++ b/pkg/analysis/anonymize_test.go
@@ -109,6 +109,131 @@ func TestGetAIResultsCombinesDeclaredAndDerivedSensitive(t *testing.T) {
 	require.Contains(t, a.Results[0].Details, "default")
 }
 
+// Derived identifiers overlap each other: a pod named after its own namespace
+// contains it as a suffix. Masking the namespace first would consume that
+// suffix and leave the "api-" stem of the pod name in the prompt.
+func TestGetAIResultsAnonymizesOverlappingNamespaceAndResource(t *testing.T) {
+	client := &recordingAIClient{}
+	a := Analysis{
+		AIClient: client,
+		Cache:    newDisabledCache(),
+		Results: []common.Result{
+			{
+				Kind: "Pod",
+				Name: "prod/api-prod",
+				Error: []common.Failure{
+					{
+						Text:      "Back-off restarting failed container of pod api-prod in namespace prod",
+						Sensitive: []common.Sensitive{},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, a.GetAIResults("json", true))
+
+	require.NotContains(t, client.prompt, "api-prod", "pod name leaked")
+	require.NotContains(t, client.prompt, "api-", "pod name was masked in pieces")
+	require.NotContains(t, client.prompt, "prod", "namespace leaked")
+
+	require.Contains(t, a.Results[0].Details, "pod api-prod")
+	require.Contains(t, a.Results[0].Details, "namespace prod")
+}
+
+// A declared value can contain a derived one just as well: an analyzer points
+// at another resource, here a backend service named after the namespace it
+// lives in. Masking the namespace out of it first leaves the "billing" stem in
+// the prompt, since nothing else covers it.
+func TestGetAIResultsAnonymizesDeclaredValueContainingDerivedOne(t *testing.T) {
+	client := &recordingAIClient{}
+	a := Analysis{
+		AIClient: client,
+		Cache:    newDisabledCache(),
+		Results: []common.Result{
+			{
+				Kind: "Ingress",
+				Name: "prod/api",
+				Error: []common.Failure{
+					{
+						Text: "Ingress uses the service billing-prod which does not exist in namespace prod",
+						Sensitive: []common.Sensitive{
+							{Unmasked: "billing-prod", Masked: "MASKED-SVC"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, a.GetAIResults("json", true))
+
+	require.NotContains(t, client.prompt, "billing-prod", "declared value leaked")
+	require.NotContains(t, client.prompt, "billing", "declared value was masked in pieces")
+	require.NotContains(t, client.prompt, "prod", "derived namespace leaked")
+
+	require.Contains(t, a.Results[0].Details, "service billing-prod")
+	require.Contains(t, a.Results[0].Details, "namespace prod")
+}
+
+// The two ways overlapping values used to go wrong, at the level of the
+// replacement itself: the shorter value eating the tail of the longer one and
+// leaving its stem in the prompt, or eating its head and splitting one
+// identifier across two masks.
+func TestMaskTextReplacesCompleteLongestMatch(t *testing.T) {
+	for name, tc := range map[string]struct {
+		pod      string
+		text     string
+		expected string
+	}{
+		"shorter value is a suffix": {
+			"api-prod",
+			"pod api-prod in namespace prod",
+			"pod POD in namespace NS",
+		},
+		"shorter value is a prefix": {
+			"prod-api",
+			"pod prod-api in namespace prod",
+			"pod POD in namespace NS",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mapping := sensitiveMapping(
+				// Declared first, and deliberately the shorter value, so the
+				// order the pairs arrive in cannot be what makes this pass.
+				[]common.Sensitive{{Unmasked: "prod", Masked: "NS"}},
+				[]common.Sensitive{{Unmasked: tc.pod, Masked: "POD"}},
+			)
+
+			require.Equal(t, tc.expected, maskText(tc.text, mapping))
+			require.Equal(t, tc.text, unmaskText(maskText(tc.text, mapping), mapping))
+		})
+	}
+}
+
+// The mapping is what makes the overlapping cases above resolve: one entry per
+// unmasked value, longest first.
+func TestSensitiveMapping(t *testing.T) {
+	declared := []common.Sensitive{
+		{Unmasked: "checkout-prod", Masked: "DECLARED"},
+		{Unmasked: "", Masked: "EMPTY-VALUE"},
+		{Unmasked: "no-mask", Masked: ""},
+	}
+	derived := []common.Sensitive{
+		{Unmasked: "prod", Masked: "DERIVED-NS"},
+		// Already declared above: the analyzer's own mask must win, and the
+		// value must not appear twice.
+		{Unmasked: "checkout-prod", Masked: "DERIVED-DUPLICATE"},
+	}
+
+	mapping := sensitiveMapping(declared, derived)
+
+	require.Equal(t, []common.Sensitive{
+		{Unmasked: "checkout-prod", Masked: "DECLARED"},
+		{Unmasked: "prod", Masked: "DERIVED-NS"},
+	}, mapping)
+}
+
 // A cluster-scoped result has a bare name with no "/" separator, and a name
 // with a leading separator must not produce an empty mask: masking the empty
 // string matches everywhere and would shred the text in both directions.

--- a/pkg/analysis/anonymize_test.go
+++ b/pkg/analysis/anonymize_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2023 The K8sGPT Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analysis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/k8sgpt-ai/k8sgpt/pkg/ai"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/cache"
+	"github.com/k8sgpt-ai/k8sgpt/pkg/common"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingAIClient captures the prompt it is handed, so a test can assert on
+// what would actually leave the machine for the provider.
+type recordingAIClient struct {
+	ai.NoOpAIClient
+	prompt string
+}
+
+func (c *recordingAIClient) GetCompletion(ctx context.Context, prompt string) (string, error) {
+	c.prompt = prompt
+	return c.NoOpAIClient.GetCompletion(ctx, prompt)
+}
+
+func newDisabledCache() cache.ICache {
+	c := cache.New("disabled-cache")
+	c.DisableCache()
+	return c
+}
+
+// TestGetAIResultsAnonymizesResourceIdentity covers issue #560: analyzers copy
+// Kubernetes event messages straight into Failure.Text with an empty
+// Failure.Sensitive, so under --anonymize the resource names inside those
+// messages were still sent to the AI provider verbatim.
+func TestGetAIResultsAnonymizesResourceIdentity(t *testing.T) {
+	client := &recordingAIClient{}
+	a := Analysis{
+		AIClient: client,
+		Cache:    newDisabledCache(),
+		Results: []common.Result{
+			{
+				Kind: "Pod",
+				Name: "prod-payments/checkout-worker-7d9f",
+				Error: []common.Failure{
+					{
+						// The shape every event-derived failure has today.
+						Text:      "Readiness probe failed for pod checkout-worker-7d9f in namespace prod-payments: connection refused",
+						Sensitive: []common.Sensitive{},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, a.GetAIResults("json", true))
+
+	require.NotContains(t, client.prompt, "checkout-worker-7d9f",
+		"pod name was sent to the AI provider despite --anonymize")
+	require.NotContains(t, client.prompt, "prod-payments",
+		"namespace was sent to the AI provider despite --anonymize")
+
+	// Masking is reversed on the way back, so the user still reads real names.
+	require.Contains(t, a.Results[0].Details, "checkout-worker-7d9f")
+	require.Contains(t, a.Results[0].Details, "prod-payments")
+}
+
+// Analyzers that already declare their own Sensitive entries must keep working
+// alongside the derived ones.
+func TestGetAIResultsCombinesDeclaredAndDerivedSensitive(t *testing.T) {
+	client := &recordingAIClient{}
+	a := Analysis{
+		AIClient: client,
+		Cache:    newDisabledCache(),
+		Results: []common.Result{
+			{
+				Kind: "StatefulSet",
+				Name: "default/example",
+				Error: []common.Failure{
+					{
+						Text: "pod example-0 in namespace default is not running, node worker.internal",
+						Sensitive: []common.Sensitive{
+							{Unmasked: "example-0", Masked: "MASKED-POD"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, a.GetAIResults("json", true))
+
+	require.NotContains(t, client.prompt, "example-0", "declared value leaked")
+	require.NotContains(t, client.prompt, "default", "derived namespace leaked")
+
+	require.Contains(t, a.Results[0].Details, "example-0")
+	require.Contains(t, a.Results[0].Details, "default")
+}
+
+// A cluster-scoped result has a bare name with no "/" separator, and a name
+// with a leading separator must not produce an empty mask: masking the empty
+// string matches everywhere and would shred the text in both directions.
+func TestResourceSensitive(t *testing.T) {
+	for name, tc := range map[string]struct {
+		resource string
+		expected []string
+	}{
+		"namespaced":     {"prod/api-server", []string{"prod", "api-server"}},
+		"cluster scoped": {"ip-10-0-1-2.ec2.internal", []string{"ip-10-0-1-2.ec2.internal"}},
+		"container":      {"prod/api-server/sidecar", []string{"prod", "api-server", "sidecar"}},
+		"empty segments": {"/api-server/", []string{"api-server"}},
+		"empty name":     {"", nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			sensitive := resourceSensitive(tc.resource)
+
+			require.Len(t, sensitive, len(tc.expected))
+			for i, want := range tc.expected {
+				require.Equal(t, want, sensitive[i].Unmasked)
+				require.NotEmpty(t, sensitive[i].Masked)
+				require.NotEqual(t, want, sensitive[i].Masked)
+			}
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -161,7 +161,16 @@ func MaskString(input string) string {
 }
 
 func ReplaceIfMatch(text string, pattern string, replacement string) string {
-	re := regexp.MustCompile(fmt.Sprintf(`%s(\b)`, pattern))
+	// An empty pattern compiles to `(\b)`, which matches at every word boundary
+	// and would rewrite the whole text.
+	if pattern == "" {
+		return text
+	}
+	// Callers pass literal values to redact (resource names, node hostnames),
+	// not regexes. Node names are routinely FQDNs, so an unescaped "." would
+	// match any character, and a value containing "+" or "(" would panic
+	// MustCompile.
+	re := regexp.MustCompile(fmt.Sprintf(`%s(\b)`, regexp.QuoteMeta(pattern)))
 	if re.MatchString(text) {
 		text = re.ReplaceAllString(text, replacement)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -251,6 +251,42 @@ func TestReplaceIfMatch(t *testing.T) {
 			replacement:    "day",
 			expectedOutput: "new day",
 		},
+		{
+			// An empty pattern compiles to `(\b)`, which matches at every word
+			// boundary and would rewrite the whole text.
+			text:           "new value",
+			pattern:        "",
+			replacement:    "X",
+			expectedOutput: "new value",
+		},
+		{
+			// The pattern is a literal to redact, not a regex: "." must not
+			// match an arbitrary character.
+			text:           "abc",
+			pattern:        "a.c",
+			replacement:    "X",
+			expectedOutput: "abc",
+		},
+		{
+			text:           "a.c",
+			pattern:        "a.c",
+			replacement:    "X",
+			expectedOutput: "X",
+		},
+		{
+			// Node names are routinely FQDNs; the dots must be literal.
+			text:           "node ip-10-0-1-2.ec2.internal is NotReady",
+			pattern:        "ip-10-0-1-2.ec2.internal",
+			replacement:    "MASKED",
+			expectedOutput: "node MASKED is NotReady",
+		},
+		{
+			// An unescaped "[" is an invalid regex and would panic MustCompile.
+			text:           "a[b value",
+			pattern:        "a[b",
+			replacement:    "X",
+			expectedOutput: "X value",
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
## What

Makes `--anonymize` actually cover the resource names that appear inside Kubernetes event messages.

## Why

Masking in `GetAIResults` is driven entirely by `Failure.Sensitive`:

```go
for _, s := range failure.Sensitive {
    failure.Text = util.ReplaceIfMatch(failure.Text, s.Unmasked, s.Masked)
}
```

Analyzers that build a failure from an event copy the message in and declare nothing sensitive:

```go
// pkg/analyzer/pod.go
if isEvtErrorReason(evt.Reason) && evt.Message != "" {
    failures = append(failures, common.Failure{
        Text:      evt.Message,
        Sensitive: []common.Sensitive{},   // -> sent to the provider verbatim
    })
}
```

So a user who explicitly asked for anonymisation still ships pod, namespace and node names to their AI provider. That is the concern in #560 — *"events may include pod names which might reveal some trade secrets."*

There are roughly 20 call sites passing an empty `Sensitive` today (`pod.go`, `pvc.go`, `job.go`, `statefulset.go`, `rs.go`, `hpa.go`, `configmap.go`, `security.go`, plus the keda/kyverno integrations). #1703 fixed one of them by hand — and even there only the non-event branch, so `statefulset.go` still leaks from its event path. Fixing them one at a time has not converged and leaves every future analyzer to re-introduce the same gap.

## Approach

Derive the masking pairs at the single point every result already passes through, from the result's own identity.

`Result.Name` is the path the analyzer keyed the resource on — `namespace/name`, `namespace/pod/container` for the container-level analyzers, a bare name for cluster-scoped ones like Node. Those segments are exactly the identifiers that appear inside event text, so splitting on `/` gives the right set for free. Analyzers that already declare their own `Sensitive` entries keep working; the two sets compose.

## Also: hardening `ReplaceIfMatch`

It interpolated its pattern straight into a regex:

```go
re := regexp.MustCompile(fmt.Sprintf(`%s(\b)`, pattern))
```

Three problems, all now fixed and covered by table cases:

- Node names are routinely FQDNs, and an unescaped `.` matches any character.
- A value containing `+` or `[` **panics** `MustCompile`.
- An empty pattern compiles to `(\b)`, which matches at every word boundary — `ReplaceIfMatch("new value", "", "X")` returned `"XnewX XvalueX"`.

Node names only begin flowing through this helper as a result of this change, so the escaping is required for the fix to be correct rather than incidental cleanup. The same empty-value hazard exists on the reverse path, where `strings.ReplaceAll` with an empty needle inserts between every character, so that is guarded too.

## Testing

Both fixes were verified to fail without the change.

Reverting the identity masking:

```
--- FAIL: TestGetAIResultsAnonymizesResourceIdentity
    Error: "...--- Readiness probe failed for pod checkout-worker-7d9f in
           namespace prod-payments: connection refused ---..."
           should not contain "checkout-worker-7d9f"
    Messages: pod name was sent to the AI provider despite --anonymize
```

Reverting the `ReplaceIfMatch` hardening:

```
--- FAIL: TestReplaceIfMatch/new_value#01
    expected: "new value"
    actual  : "XnewX XvalueX"
--- FAIL: TestReplaceIfMatch/abc
    expected: "abc"
    actual  : "X"
```
(plus a panic on the `[` case)

The new test asserts on the prompt handed to the AI client, so it checks what would actually leave the machine, and also asserts the masking is reversed so the user still reads real names in the output.

With the change:

```
$ go test ./pkg/analysis/... ./pkg/util/... ./pkg/analyzer/...
ok  	github.com/k8sgpt-ai/k8sgpt/pkg/analysis	12.789s
ok  	github.com/k8sgpt-ai/k8sgpt/pkg/analyzer	9.179s
```

`pkg/util` has one unrelated pre-existing failure on Windows only (`TestEnsureDirExists` asserts a Unix `mkdir` error string); it fails identically on a clean checkout of `main` and passes on the Linux CI runner.

## Scope

Deliberately not attempting to mask image references or registry paths out of free-text event messages. Extracting those reliably needs real parsing, and feeding values containing `.`/`+`/`:` through the redaction helper is what makes the regex issues above dangerous. #560 asks specifically about resource names, which this covers.

Closes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVmaNMnAydzyhpPwcjPavH
