### PR TITLE
fix: guard against empty completion choices in OpenAIClient

### DIFF
--- a/pkg/ai/openai.go
+++ b/pkg/ai/openai.go
@@ -103,6 +103,9 @@ func (c *OpenAIClient) GetCompletion(ctx context.Context, prompt string) (string
 	if err != nil {
 		return "", err
 	}
+	if len(resp.Choices) == 0 {
+		return "", errors.New("no completion choices returned from the AI provider")
+	}
 	return resp.Choices[0].Message.Content, nil
 }
 

--- a/pkg/ai/openai_header_transport_test.go
+++ b/pkg/ai/openai_header_transport_test.go
@@ -116,3 +116,22 @@ func TestOpenAIClient_CustomHeaders(t *testing.T) {
 	_, err = client.GetCompletion(ctx, "foo prompt")
 	assert.NoError(t, err)
 }
+
+func TestOpenAIClient_GetCompletionNoChoices(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"choices": []}`))
+		if err != nil {
+			t.Fatalf("error writing response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client := &OpenAIClient{}
+	err := client.Configure(&mockConfig{baseURL: server.URL})
+	assert.NoError(t, err)
+
+	_, err = client.GetCompletion(context.Background(), "foo prompt")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no completion choices")
+}


### PR DESCRIPTION
Closes #1524

## 📑 Description
`OpenAIClient.GetCompletion` (in `pkg/ai/openai.go`) indexed `resp.Choices[0]` without
checking that the provider actually returned any choices. If an OpenAI-compatible
backend responds with HTTP 200 and an empty `choices` array — which can happen with
self-hosted backends such as LocalAI/Ollama when a model call silently fails, times
out, or is filtered — this panics with `index out of range [0] with length 0`.
Because `LocalAIClient` (used by the `localai` backend referenced in this issue) is a
bare embed of `OpenAIClient` with no override of `GetCompletion`, it inherits this
same panic risk. The same defensive check already exists for the `litellm` backend
(`pkg/ai/litellm.go`) and OpenAI-compatible clients rely on go-openai for HTTP-level
error handling only, not for guarding an empty `choices` slice on a 200 response — this
change adds the same guard for `openai`/`localai`.

**Disclosure / scope**: the two failure logs in the issue thread (`connection refused`
to `localhost` from inside a pod, and a `404`/`json: cannot unmarshal number into Go
value of type openai.ErrorResponse`) are caused by network/baseURL configuration
against the reporter's own Ollama deployment, not by a k8sgpt defect — go-openai's
`handleErrorResp` already turns a malformed error body into a readable `RequestError`
rather than crashing, so there's nothing to fix there in this codebase. This PR does
not reproduce or resolve those two specific log lines. It fixes an adjacent, provable
defect in the same `localai`/`openai` code path: the missing empty-choices guard,
which is a real panic risk regardless of the specific backend URL involved.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
**Validation**:
- Added `TestOpenAIClient_GetCompletionNoChoices` to `pkg/ai/openai_header_transport_test.go`.
  Verified it panics on the pre-fix code (`index out of range [0] with length 0`) and
  passes after the fix, by stashing only the `pkg/ai/openai.go` change and re-running:
  `go test ./pkg/ai/... -run TestOpenAIClient_GetCompletionNoChoices -v`.
- `go build ./pkg/ai/...` — passes.
- `go test ./pkg/ai/...` (full package) — passes.
- `golangci-lint run ./pkg/ai/...` (v2.12.2, matching `.github/workflows/golangci_lint.yaml`) —
  reports 15 pre-existing issues in the package, none in the two files touched by this change.
- Base branch (`main`) CI (`Run tests`, `golangci-lint`) is currently green.

No breaking changes; no new dependencies. No user-visible behavior change for the
success path — only replaces a panic with a returned error when a provider returns
zero completion choices.